### PR TITLE
Disable pointer-events on datepicker__trigger__icon

### DIFF
--- a/less/style/blocks/datepicker.less
+++ b/less/style/blocks/datepicker.less
@@ -54,6 +54,7 @@
   fill: @color-light-blue;
   display: inline-block;
   vertical-align: middle;
+  pointer-events: none;
 }
 
 .picker {


### PR DESCRIPTION
Disable pointer-events on datepicker__trigger__icon so it opens correctly.

@davidknezic , @elessar-ch merge?