### PR TITLE
Fix stop word behavior in search

### DIFF
--- a/docs/js/search.coffee
+++ b/docs/js/search.coffee
@@ -84,11 +84,9 @@ class Search
     @updateDisplay()
 
   initIndex: (data, textStatus, jqXHR) ->
-
     @searchData = data
-
     @lunrIdx = lunr.Index.load @searchData.lunr
-
+    @lunrIdx.pipeline.remove lunr.stopWordFilter
     @initialized = true
 
     # in case the target node is already focus'ed

--- a/docs/page/changelog.jade
+++ b/docs/page/changelog.jade
@@ -1,6 +1,7 @@
 ---
 title: What's new
 template: page.jade
+tags: changelog, changes
 ---
 
 if config.changelog

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "metalsmith-define": "1.0.0",
     "metalsmith-drafts": "0.0.1",
     "metalsmith-filepath": "^1.0.1",
+    "metalsmith-ignore": "^0.1.2",
     "metalsmith-jade": "0.0.3",
     "metalsmith-lunr": "git+https://github.com/sventschui/metalsmith-lunr",
     "metalsmith-markdown": "git+https://github.com/axa-ch/metalsmith-markdown",

--- a/tasks/docs-pages.coffee
+++ b/tasks/docs-pages.coffee
@@ -1,6 +1,3 @@
-#
-# The Metalsmith workflow that builds our docs.
-#
 path = require 'path'
 marked = require 'marked'
 colors = require 'colors'
@@ -88,7 +85,7 @@ module.exports = (cb) ->
     'nav__components__form',
     'nav__patterns',
     'nav__inspiration'
-  ].forEach (name) ->
+  ].forEach (name) =>
     collections_options[name] =
       sortBy: 'order'
       reverse: false
@@ -122,26 +119,35 @@ module.exports = (cb) ->
     branch ['**/*.html']
       .use copy
         pattern: '**/snippets/*.html'
-        transform: (file) ->
-          return file.replace /snippets/i, 'demos'
+        transform: (file) => file.replace /snippets/i, 'demos'
   )
 
-  # Wrap the pages with their template
   metalsmith.use ignore '**/includes/**'
 
+  # Add some pages to the search index
   metalsmith.use(
-    branch ['**/*.html', '!**/snippets/*.html' ]
+    branch [
+        '**/*.html'
+        '!**/snippets/*.html'
+        '!**/demos/*.html'
+      ]
       .use filepath
         absolute: true
-      .use lunr {
+      .use lunr
         includeAll: true
-        fields: {
+        fields:
           title: 10
           tags: 5
           contents: 1
-        }
-      }
       .use searchIndexData()
+  )
+
+  # Wrap the pages with their template
+  metalsmith.use(
+    branch [
+        '**/*.html'
+        '!**/snippets/*.html'
+      ]
       .use templates
         engine: 'jade'
         directory: path.join cwd, './docs/layouts'

--- a/tasks/docs-pages.coffee
+++ b/tasks/docs-pages.coffee
@@ -28,6 +28,7 @@ filepath = require 'metalsmith-filepath'
 relative = require 'metalsmith-relative'
 lunr = require 'metalsmith-lunr'
 copy = require 'metalsmith-copy'
+ignore = require 'metalsmith-ignore'
 
 module.exports = (cb) ->
   cwd = path.join __dirname, '../'
@@ -126,6 +127,8 @@ module.exports = (cb) ->
   )
 
   # Wrap the pages with their template
+  metalsmith.use ignore '**/includes/**'
+
   metalsmith.use(
     branch ['**/*.html', '!**/snippets/*.html' ]
       .use filepath


### PR DESCRIPTION
Lunr has a great feature which filters common words like `but` or `and`. It's a great way to reduce the index size. But strangely it does the same to the search query you type in.

That's why the query `bu` gets you multiple button results, but the query `but` returns an empty list. #296

This PR removes the stop word filter on the client side. It also removes demo pages from the index.