### PR TITLE
Fix naming, improve text

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,5 +1,6 @@
 {
-  "description": "AXA Switzerland Web Design Guide",
+  "name": "Web Style Guide",
+  "description": "AXA Switzerland Web Style Guide",
   "keywords": [
     "axa",
     "switzerland",
@@ -9,7 +10,7 @@
     "guide"
   ],
   "author": "AXA Versicherungen AG",
-  "copyright": "Copyright AXA Versicherungen AG 2015",
+  "copyright": "© AXA Versicherungen AG 2015",
   "repository": {
     "name": "axa-ch/style-guide",
     "url": "https://github.com/axa-ch/style-guide"

--- a/docs/layouts/demo.jade
+++ b/docs/layouts/demo.jade
@@ -13,7 +13,7 @@ html
     meta(name="keywords", content=config.keywords)
     meta(name="author", content=config.author)
         
-    title #{title} | Demo | Web Styleguide
+    title #{title} | Demo | #{config.name}
     link(rel="stylesheet", href="//fast.fonts.net/cssapi/1da4c08a-73a4-4e34-8997-1c1eeb1a8cca.css")
     link(rel="stylesheet", href=relative("/css/normalize.min.css"))
     link(rel="stylesheet", href=relative("/css/style.min.css"))

--- a/docs/layouts/examples/master.jade
+++ b/docs/layouts/examples/master.jade
@@ -27,7 +27,7 @@ html
     +appicon_ios("152")
     +appicon_ios("180")
 
-    meta(name="apple-mobile-web-app-title", content="Web Stylegudie")
+    meta(name="apple-mobile-web-app-title", content=config.name)
 
     link(href="images/splash-screen/ios/750x1294.png", media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)", rel="apple-touch-startup-image")
 
@@ -37,13 +37,13 @@ html
     meta(name="mobile-web-app-capable", content="yes")
 
     // windows tiles
-    meta(name="application-name", content="Web Styleguide")
+    meta(name="application-name", content=config.name)
     meta(name="msapplication-square70x70logo", content="images/app-icon/windows/128x128.png")
     meta(name="msapplication-square150x150logo", content="images/app-icon/windows/270x270.png")
     meta(name="msapplication-wide310x150logo", content="images/app-icon/windows/558x270.png")
     meta(name="msapplication-square310x310logo", content="images/app-icon/windows/558x558.png")
 
-    title #{title} | Web Styleguide
+    title #{title} | #{config.name}
     link(rel="stylesheet", href="//fast.fonts.net/cssapi/1da4c08a-73a4-4e34-8997-1c1eeb1a8cca.css")
     link(rel="stylesheet", href=relative("/css/style.min.css"))
 
@@ -133,7 +133,7 @@ html
           .l-container
             ul.menu.menu--copyline
               li.menu__item
-                span.menu__link AXA 2015 ©
+                span.menu__link= config.copyright
 
     .site__mobile-menu
 

--- a/docs/layouts/page.jade
+++ b/docs/layouts/page.jade
@@ -29,7 +29,7 @@ html
     +appicon_ios("152")
     +appicon_ios("180")
     
-    meta(name="apple-mobile-web-app-title", content="Web Styleguide")
+    meta(name="apple-mobile-web-app-title", content=config.name)
       
     link(media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)", rel="apple-touch-startup-image", href=relative("/images/splash-screen/ios/750x1294.png"))
     
@@ -39,13 +39,13 @@ html
     meta(name="mobile-web-app-capable", content="yes")
       
     // windows tiles
-    meta(name="application-name", content="Web Styleguide")
+    meta(name="application-name", content=config.name)
     meta(name="msapplication-square70x70logo", content=relative("/images/app-icon/windows/128x128.png"))
     meta(name="msapplication-square150x150logo", content=relative("/images/app-icon/windows/270x270.png"))
     meta(name="msapplication-wide310x150logo", content=relative("/images/app-icon/windows/558x270.png"))
     meta(name="msapplication-square310x310logo", content=relative("/images/app-icon/windows/558x558.png"))
 
-    title #{title} | Web Styleguide
+    title #{title} | #{config.name}
     link(rel="stylesheet", href="//fast.fonts.net/cssapi/1da4c08a-73a4-4e34-8997-1c1eeb1a8cca.css")
     link(rel="stylesheet", href=relative("/css/normalize.min.css"))
     link(rel="stylesheet", href=relative("/css/docs.min.css"))
@@ -101,7 +101,7 @@ html
               .header__meta__welcome
                 div
                   .header__meta__welcome__main
-                    span Web Styleguide
+                    span= config.name
 
                   // ko if: hasGitHubIntegration && github.isSignedIn()
                   .header__meta__welcome__secondary
@@ -186,7 +186,7 @@ html
               li.menu__item
                 a(href=relative('/changelog.html')).menu__link Changelog
               li.menu__item
-                span.menu__link AXA 2015 ©
+                span.menu__link= config.copyright
 
     script(type='text/javascript').
       //// Set the right mobile menu level as current

--- a/docs/page/fundamentals/accessibility/basics.jade
+++ b/docs/page/fundamentals/accessibility/basics.jade
@@ -6,9 +6,15 @@ template: page.jade
 tags: accessibility, barrierefreiheit
 ---
 
-p.paragraph.
-  There are around one million impaired people in Switzerland. Persons with disabilities include those who have long-term physical, mental, intellectual or sensory impairments which in interaction with various barriers may hinder their full and effective participation in society on an equal basis with others. (UN Convention on the Rights of Persons with Disabilities, Art. 1, Abs.2). 
+:markdown
+  There are around one million impaired people in Switzerland.
+  Persons with disabilities include those who have long-term physical,
+  mental, intellectual or sensory impairments which in interaction
+  with various barriers may hinder their full and effective participation
+  in society on an equal basis with others.
+  (UN Convention on the Rights of Persons with Disabilities, Art. 1, Abs.2). 
 
-p.paragraph.
-  As AXA Switzerland we identified WCAG 2.0 (AA) as an appropriate standard for B2C websites and applications.
-  Complete information about the standard and how follow the standard can be found on the <a href="http://www.w3.org/TR/WCAG20/" target="_blank">w3c website</a>.
+  As AXA Switzerland we identified WCAG 2.0 (AA) as an appropriate standard
+  for B2C websites and applications.
+  Complete information about the standard and how follow
+  the standard can be found on the [w3c website](http://www.w3.org/TR/WCAG20/).

--- a/docs/page/fundamentals/code/bem.jade
+++ b/docs/page/fundamentals/code/bem.jade
@@ -4,18 +4,23 @@ order: 2
 collection: nav__fundamentals__code
 template: page.jade
 ---
-p.paragraph.
-  BEM stands for Block, Element Modifier and describes a set of front end development techniques. BEM is originated by the Russian internet giant Yandex.
 
-p.paragraph.
-  We adopted the BEM methodology in the Web Design Guide. Each component defined by the Design Guidelines is implemented by one or more blocks. Therefore the CSS and HTML is aligned to BEM.
+:markdown
+  BEM stands for Block, Element Modifier and describes a set of
+  front end development techniques.
+  BEM is originated by the Russian internet giant Yandex.
+
+  We adopted the BEM methodology in the Web Style Guide.
+  Each component defined by our guidelines is implemented by one or
+  more blocks. Therefore the CSS and HTML is aligned to BEM.
   
-p.paragraph.
-  This is a quick overview over the BEM methodology and how we adapted it to fit our needs. If you want to take a deep dive head over to <a href="https://bem.info/method/definitions/" class="link">bem.info</a>.
+  This is a quick overview over the BEM methodology and how we adapted
+  it to fit our needs. If you want to take a deep dive head over to
+  [bem.info](https://bem.info/method/definitions/).
 
-
-ul.list.list--unordered
- li.list__item We recommend using the same principles for your app, to enhance integration of the Web Design Guide and enhance your web development experience.
+  * We recommend using the same principles for your app,
+    to enhance integration of the Web Style Guide and
+    enhance your web development experience.
 
 .toc
   .toc__title Table of contents
@@ -29,67 +34,72 @@ ul.list.list--unordered
     li.toc__anchor-navigation__item
       a(href='#naming').toc__anchor-navigation__link Naming
     li.toc__anchor-navigation__item
-      a(href='#independent').toc__anchor-navigation__link Independent CSS
+      a(href='#independent-css').toc__anchor-navigation__link Independent CSS
     li.toc__anchor-navigation__item
       a(href='#javascript').toc__anchor-navigation__link Javascript
 
-h2.heading.heading--secondary#elements Elements
- 
-p.paragraph.
-   Elements are always part of a block and are thus context dependent. They cannot exist on their own.
- 
-p.paragraph.
- For example, a menu item can only exist inside a menu. Makes sense, right?
-   
-img(src=relative('/images/bem/elements.svg') alt="These are elements")
+:markdown
+  # Elements
 
-h2.heading.heading--secondary#blocks Blocks
+  Elements are always part of a block and are thus context dependent.
+  They cannot exist on their own.
 
-p.paragraph.
+  For example, a menu item can only exist inside a menu. Makes sense, right?
+
+  ![These are elements](/images/bem/elements.svg)
+
+  # Blocks
+
   A page consists of several blocks, such as header, footer, menu and more.
 
-p.paragraph.
-  Blocks are always independent. This means that they could appear anywhere on any page or even multiple times on the same page. For example a menu block may appear once on top of the page and once on the side to create a two-step navigation.
+  Blocks are always independent. This means that they could appear
+  anywhere on any page or even multiple times on the same page.
+  For example a menu block may appear once on top of the page and once
+  on the side to create a two-step navigation.
 
-p.paragraph.
-  Blocks can contain elements and also other nested blocks to reuse functionality and minimize complexity. A block describes the order in which it's children appear.
+  Blocks can contain elements and also other nested blocks to reuse
+  functionality and minimize complexity.
+  A block describes the order in which it's children appear.
 
-img(src=relative('/images/bem/blocks.svg') alt="This is a block")
+  ![This is a block](/images/bem/blocks.svg)
 
-//h3.heading.heading--tertiary Blocks and Elements united
-//img(src=relative('/images/bem/bem.svg') alt="This is a block")
+  # Modifiers
 
-h2.heading.heading--secondary#modifiers Modifiers
+  Modifiers define the styling of a block or element.
+  Every modifier has its own CSS class.
+  This way you can use a menu block for a top navigation,
+  and another for a side navigation and give them both
+  the appropriate styling.
 
-p.paragraph.
-  Modifiers define the styling of a block or element. Every modifier has its own CSS class. This way you can use a menu block for a top navigation, and another for a side navigation and give them both the appropriate styling.
-
-p.paragraph.
   Multiple modifiers in a block or element are allowed.
 
-h2.heading.heading--secondary#naming Naming
+  # Naming
 
-p.paragraph.
-  Block names must be unique within the project and element names must be unique within their block. We separate nested blocks and elements with the <code>__</code> (double lower dash) sequence and modifiers from blocks and elements with the <code>--</code> (double dash) sequence.
+  Block names must be unique within the project and element names must
+  be unique within their block.
+  We separate nested blocks and elements
+  with the `__` (double lower dash) sequence and modifiers
+  from blocks and elements with the `--`
+  (double dash) sequence.
 
-ul.list.list--unordered
-  li.list__item Don't use names in your app, that are already used by the Web Design Guide.
+  * Don't use names in your app, that are already used by the Web Style Guide.
 
-h2.heading.heading--secondary#independent Independent CSS
+  # Independent CSS
+  
+  To achieve block independence, so that blocks can be on
+  their own and anywhere on a page, we follow
+  the following rules in our CSS definitions:
+  
+  * HTML elements (`h1`, `p`, `div`) _must not_ be used in CSS selectors.
+  * Cascading selectors (`.menu.menu--item { ... }`) _should not_ be used.
+  * ID based selectors (`#menu { ... }`) _must not_ be used.
 
-p.paragraph.
-  To achieve block independence, so that blocks can be on their own and anywhere on a page, we follow the following rules in our CSS definitions:
-ul.list.list--unordered
-  li.list__item HTML elements (<code>h1</code>, <code>p</code>, <code>div</code>) <strong>must not</strong> be used in CSS selectors.
-  li.list__item Cascading selectors (<code>.menu.menu--item { ... }</code>) <strong>should not</strong> be used.
-  li.list__item ID based selectors (<code>#menu { ... }</code>) <strong>must not</strong> be used.
+  # JavaScript
 
-h2.heading.heading--secondary#javascript Javascript
+  You should apply behaviour with javascript on block level.
+  Use CSS classes to select every instance of a block on your page.
 
-p.paragraph.
-  You should apply behaviour with javascript on block level. Use CSS classes to select every instance of a block on your page.
-
-p.paragraph.
-  If you have the need, you can also write a Javascript libraray to easily access blocks and elements.
+  If you have the need, you can also write a JavaScript
+  libraray to easily access blocks and elements.
 
 //- Copyright AXA Versicherungen AG 2015

--- a/docs/page/fundamentals/code/browser-support.jade
+++ b/docs/page/fundamentals/code/browser-support.jade
@@ -6,7 +6,7 @@ template: page.jade
 tags: safari, ios, chrome, android, internet explorer, firefox,
 ---
 
-p.paragraph.
+:markdown
   Customers, partners and employees are using an
   extensive amount of different browsers.
   Therefore, websites and applications should cater
@@ -14,9 +14,8 @@ p.paragraph.
   technologies in or for different browsers.
   The W3C standards are also our standards.
 
-h2.heading.heading--secondary What browsers to support?
+  # What browsers to support?
 
-p.paragraph.
   Based on data from the 13th of may 2015, we are
   supporting the following browsers and mobile
   operating systems:
@@ -97,19 +96,17 @@ table.table.table--docs
 
 .hr
 
-h2.heading.heading--secondary Internet Explorer 8 & 9
+:markdown
+  # Internet Explorer 8 & 9
 
-p.paragraph.
   You'll need to add some of the polyfills listed
   below to add support for IE 9.
 
-p.paragraph.
   With the current release Internet Explorer 8 is
   NOT supported. Please consider adding a "Your
   browser is not supported page" or add support
   for IE 8 on your own. The polyfills listed below
   will do the major parts of the job.
-
 
 table.table.table--docs
   thead

--- a/docs/page/fundamentals/code/faq.md
+++ b/docs/page/fundamentals/code/faq.md
@@ -83,13 +83,13 @@ and this Developer Toolkit is based on it.
 > Have a look at our <code>icons.less.lodash</code> file for
 > a real world example.
 
-# What JavaScript libraries does the Web Styleguide need?
+# What JavaScript libraries does the Web Style Guide need?
 To stay independent from any client or server side UI logic, we always develop
 the HTML markup and LESS/CSS styles first, for any component. You can use
 the static markup and styles to create your application and write
 all the behavior using your preferred frameworks and libraries.
 
-> JavaScript is required to implement certain behaviours the Web Styleguide
+> JavaScript is required to implement certain behaviours the Web Style Guide
 > defines.
 
 # What about the jQuery plugins?
@@ -102,7 +102,7 @@ interacting with other code. Most of the time the problem lies with multiple
 components tracking and manipulating the DOM.
 In this case it's often better to let go of our plugins, and implement the
 behavior the way, your library intends to. Of course you may reuse code from
-the Web Styleguide.
+the Web Style Guide.
 
 # Recommended libraries (Draft)
 | Library | Remarks |

--- a/docs/page/fundamentals/code/getting-started.jade
+++ b/docs/page/fundamentals/code/getting-started.jade
@@ -8,7 +8,7 @@ template: page.jade
 aside.callout
   h2.callout__heading Feedback appreciated!
   p.paragraph
-    | The Web Styleguide aims to support you in building awesome
+    | The Web Style Guide aims to support you in building awesome
     | responsive web sites and apps. If you struggle using the assets, 
     | miss a component or face any other issue please feel free to
     = ' '
@@ -53,7 +53,7 @@ p.paragraph.
 
 .callout.callout--danger
   p.paragraph.
-    The Webserver hosting the style guide doesn't like the default user agent used by bower.
+    The webserver hosting the Web Style Guide doesn't like the default user agent used by bower.
     Therefore you need to configure a custom user agent string in your .bowerrc.
 
   .highlight: pre.highlight__listing.hljs: code.json
@@ -74,7 +74,7 @@ p.paragraph.
 h2.heading.heading--secondary What's included
 
 p.paragraph.
-  The web styleguide is delivered in two diffrent flavours.
+  The Web Style Guide is delivered in two diffrent flavours.
   The npm package and the dist package (raw download and bower).
   Compare the structures below.
 
@@ -144,7 +144,7 @@ dl
     </div>
   </div>
           
-  # Using the Web Styleguide
+  # Using the Web Style Guide
 
   ## Basic template
 
@@ -152,7 +152,7 @@ dl
   <!DOCTYPE html>
   <html lang="en">
     <head>
-      <title>AXA Web Styleguide - Basic template</title>
+      <title>AXA Web Style Guide - Basic template</title>
 
       <!-- meta tags as explained in the recommendations page -->
       <meta charset="utf-8">
@@ -213,7 +213,7 @@ dl
 
   <p class="callout" >
     The following examples assume that you have added the
-    `less/` folder of the Web Styleguide to the LESS compilers
+    `less/` folder of the Web Style Guide to the LESS compilers
     paths.
   </p>
 
@@ -235,7 +235,7 @@ dl
   @import 'style/blocks/footer';
   ```
 
-  #### Including the entire Web Styleguide
+  #### Including the entire Web Style Guide
 
   This approach may be used for prototyping but it is not recommended
   in a productive setup since it will add a lot of CSS markup you don't need.

--- a/docs/page/fundamentals/design/appicon-and-splashscreen.jade
+++ b/docs/page/fundamentals/design/appicon-and-splashscreen.jade
@@ -5,43 +5,30 @@ collection: nav__fundamentals__design
 template: page.jade
 ---
 
-p.paragraph.
+:markdown
   We recommend to create square app icons since the devices will cut 
   round corners on their own.
-//  
-//-p.paragraph.
-  TODO: AXA group guidelines and PSDs?!?
-  
-//-p.paragraph.
-  TODO: Guidelines for windows tiles
-  
-//-h2.heading.heading--secondary Splash screen
 
-//-p.paragraph.
-  TODO
-  
-h2.heading.heading--secondary App icon
+  # App icon
 
-p.paragraph.
   Produce the app icon in various sizes to cover diffrent devices/os. Use
   the tables below as a guideline on choosing the appropriate sizes.
   
-p.paragraph.
   See the screenshots to the right for examples.
 
-h3.heading.heading--tertiary iOS App icon  
+  ## iOS App icon  
 
 .l-row
   .l-col.l-col--7
-    p.paragraph.
+    :markdown
       Add a link tag for every app icon size to the head section. See the example
       for a 114x114px app icon below.
 
-    .highlight: pre.highlight__listing.hljs: code.js
-      :highlight
-        <link rel="apple-touch-icon" href="icon114.png" sizes="114x114">
-        <!-- Use the -precomposed rel to prevent icon modification in iOS 2.0-6.x -->
-        <link rel="apple-touch-icon-precomposed" href="icon114.png" sizes="114x114">
+      ```js
+      <link rel="apple-touch-icon" href="icon114.png" sizes="114x114">
+      <!-- Use the -precomposed rel to prevent icon modification in iOS 2.0-6.x -->
+      <link rel="apple-touch-icon-precomposed" href="icon114.png" sizes="114x114">
+      ```
       
     table.table.table--docs
       caption App icon sizes for iOS devices in pixels
@@ -93,13 +80,10 @@ h3.heading.heading--tertiary Android app icon
 
 .l-row
   .l-col.l-col--7
-      
-    p.paragraph
-      | This section is based on the 
-      a(href="https://developer.chrome.com/multidevice/android/installtohomescreen").link Chrome for Android guides
-      | .
-      
-    p.paragraph.
+    :markdown
+      This section is based on the 
+      [Chrome for Android guides](https://developer.chrome.com/multidevice/android/installtohomescreen).
+
       Since android has a wide os and browser fragmentation you may experience some issues.
       Do not hesitate to open a pull request to improve this section!
       
@@ -157,19 +141,19 @@ h3.heading.heading--tertiary Windows tiles
 
 .l-row
   .l-col.l-col--7
-    p.paragraph.
+    :markdown
       You can set an application name, a background color and an 
       (optionally transparent) icon for a windows tile. 
       See the example below.
       
-    .highlight: pre.highlight__listing.hljs: code.js
-      :highlight
-        <meta name="application-name" content="My fancy application"/>
-        <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="msapplication-square70x70logo" content="tiny.png"/>
-        <meta name="msapplication-square150x150logo" content="square.png"/>
-        <meta name="msapplication-wide310x150logo" content="wide.png"/>
-        <meta name="msapplication-square310x310logo" content="large.png"/>
+      ```js
+      <meta name="application-name" content="My fancy application"/>
+      <meta name="msapplication-TileColor" content="#ffffff"/>
+      <meta name="msapplication-square70x70logo" content="tiny.png"/>
+      <meta name="msapplication-square150x150logo" content="square.png"/>
+      <meta name="msapplication-wide310x150logo" content="wide.png"/>
+      <meta name="msapplication-square310x310logo" content="large.png"/>
+      ```
       
     table.table.table--docs
       caption Tile icon sizes for Windows devices in pixels
@@ -218,6 +202,5 @@ h3.heading.heading--tertiary Windows tiles
             .table__row__item__content 558 x 558
   .l-col.l-col--5
     img(src=relative('/images/design/app-icons-windows.png'))
-
 
 //- Copyright AXA Versicherungen AG 2015

--- a/docs/page/fundamentals/design/colors.jade
+++ b/docs/page/fundamentals/design/colors.jade
@@ -8,10 +8,12 @@ template: page.jade
 include ../../components/includes/mixins.jade
 
 p.paragraph.
-  Use these colors to guide your designs and to ensure you’re staying consistent with the AXA brand.
+  Use these colors to guide your designs and to ensure you’re
+  staying consistent with the AXA brand.
 
 p.callout
-  | Copy the color code or the less variable name to the clipboard by clicking the 
+  | Copy the color code or the less variable name to the
+  | clipboard by clicking the 
   +svg('clipboard', ['color-palette__key__icon', 'icon-svg'])
   |  icon below.
 

--- a/docs/page/fundamentals/design/icons.jade
+++ b/docs/page/fundamentals/design/icons.jade
@@ -10,10 +10,14 @@ include ../../components/includes/mixins
 h1.heading.heading--primary Available icons
 
 p.paragraph.
-  An icon is a graphic that takes up a small portion of screen and provides a quick, intuitive representation of an action or a status.
+  An icon is a graphic that takes up a small portion of
+  screen and provides a quick, intuitive representation of
+  an action or a status.
 
 p.paragraph.
-  For all AXA Applications use Helveticons, which are based on the Helvetica Bold typeface.  If you need further icons please contact us.
+  For all AXA Applications use Helveticons,
+  which are based on the Helvetica Bold typeface.
+  If you need further icons please contact us.
 
 .downloads
   +svg('download', ['downloads__icon', 'icon-svg'])

--- a/docs/page/fundamentals/layout/devices.jade
+++ b/docs/page/fundamentals/layout/devices.jade
@@ -7,7 +7,9 @@ tags: iphone, smartphone, tablet, media query, desktop, mobile
 ---
 
 p.paragraph.
-  New devices with different viewports, screen sizes, input modes and other specific attributes are released on a daily basis. As of May 2015, we suggest to design for the following device classes:
+  New devices with different viewports, screen sizes,
+  input modes and other specific attributes are released on a daily basis.
+  As of May 2015, we suggest to design for the following device classes:
 
 .l-row(style='text-align: center; background: #eee; padding: 20px; margin: 20px 0;')
   div(style='padding: 10px 0; font-size: 1.2em; font-weight: 600;').
@@ -45,23 +47,31 @@ p.paragraph.
     p.paragraph.
       1280px +
 
-h2.heading.heading--secondary#theUnknown The Unknown
-p.paragraph This device class is a mixture of different types of users.
-ul.list.list--unordered
-  li.list__item either on a tablet or a desktop / laptop computer
-  li.list__item screen sizes ranging from 7inch (iPad Mini Size) up to 13inches (normal laptop)
-  li.list__item 25% of our current desktop users belong into this device class, decreasing share
-  li.list__item 8% of mobile & tablet users belong into this device class. increasing share
+:markdown
+  # The Unknown
+  
+  This device class is a mixture of different types of users.
+  
+  * either on a tablet or a desktop / laptop computer
+  * screen sizes ranging from 7inch (iPad Mini Size) up to 13inches (normal laptop)
+  * 25% of our current desktop users belong into this device class, decreasing share
+  * 8% of mobile & tablet users belong into this device class. increasing share
 
-h3.heading.heading--tertiary Recommendations
-p.paragraph As of May 2015 the following ideas are recommended
-ul.list.list--unordered
-  li.list__item Use analytics to figure out which audience you serve and how to implement this device class in your project – know your customer.
-  li.list__item If in doubt, lower the desktop breakpoint to 1025 min-width
+  ## Recommendations
+  
+  As of May 2015 the following ideas are recommended
+  
+  * Use analytics to figure out which audience you serve and how to
+    implement this device class in your project – know your customer.
+  * If in doubt, lower the desktop breakpoint to 1025 min-width
 
-p.paragraph This style guide does not have special designs for this device class. Use whatever is more appropriate in your context.
+  The Web Style Guide does not have special designs for this device class.
+  Use whatever is more appropriate in your context.
 
-h3.heading.heading--tertiary Prepare for the future
-p.paragraph As of CSS4, new media query options (e.g. pointer) will be available. Prepare that this device class might get split into two separate categories with overlapping viewport sizes.
+  ## Prepare for the future
+  
+  As of CSS4, new media query options (e.g. pointer) will be available.
+  Prepare that this device class might get split into two separate
+  categories with overlapping viewport sizes.
 
 //- Copyright AXA Versicherungen AG 2015

--- a/docs/page/index.jade
+++ b/docs/page/index.jade
@@ -15,7 +15,7 @@ mixin thumbnail(item)
       p.thumbnail__text!= item.description
   
 .l-container.l-container--docs-home
-  h1.heading.heading--docs-home Welcome to the AXA Web Styleguide  
+  h1.heading.heading--docs-home Welcome to the AXA Web Style Guide
   - var items = collections['nav']
   if items
     - var i = 0

--- a/docs/page/patterns/forms.jade
+++ b/docs/page/patterns/forms.jade
@@ -8,7 +8,9 @@ template: page.jade
 include ../components/includes/mixins.jade
 
 p.paragraph.
-  Try to find someone who likes filling forms, you won't. This is the reason why we built this guide on how to build  less annoying and better performing forms for AXA.
+  Try to find someone who likes filling forms, you won't.
+  This is the reason why we built this guide on how to build
+  less annoying and better performing forms for AXA.
 
 .toc
   .toc__title Table of contents
@@ -25,7 +27,11 @@ p.paragraph.
 h2.heading.heading--secondary#organisation Form Organisation
 
 p.paragraph.
-  Organize your form as a conversation, use natural breaks and group related questions. Use the minimal amount of visual information to distinguish different content groups. Avoid visual clutter and don't interrupt scan lines.
+  Organize your form as a conversation,
+  use natural breaks and group related questions.
+  Use the minimal amount of visual information to distinguish
+  different content groups. Avoid visual clutter
+  and don't interrupt scan lines.
 
 h3.heading.heading--tertiary UX Checklist
 ul.checklist
@@ -52,14 +58,21 @@ ul.checklist
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      Speak with one voice, despite questions from different people or departments.
+      Speak with one voice, despite questions from
+      different people or departments.
 
 .hr
 
 h2.heading.heading--secondary#path Path To Completion
 
 p.paragraph.
-  A straight path to completion is important for an efficient form filling process. Especially complex forms, e.g. claim reporting, require proper guidance. This guidance depends on a superb navigation, clear scan lines as well as an well-organized form. On long & paginated forms, an introductory page may be used to give upfront information about the form to follow.
+  A straight path to completion is important for an
+  efficient form filling process. Especially complex forms,
+  e.g. claim reporting, require proper guidance.
+  This guidance depends on a superb navigation,
+  clear scan lines as well as an well-organized form.
+  On long & paginated forms, an introductory page may be used
+  to give upfront information about the form to follow.
 
 h3.heading.heading--tertiary Bad Scan Line
 img(src=relative('/images/pattern/forms-scanlines-bad.svg') alt="Bad Scan Line")
@@ -72,27 +85,35 @@ ul.checklist
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      On desktop, right align labels because this allows easier scanning and filling of the form.
+      On desktop, right align labels because
+      this allows easier scanning and filling of the form.
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      On mobile, put the labels above the form element because horizontal space is limited and scanning stays very easy.
+      On mobile, put the labels above the form element because
+      horizontal space is limited and scanning stays very easy.
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      Provide a meaningful title for every form because users need to know they are at the right place
+      Provide a meaningful title for every form because
+      users need to know they are at the right place
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      Remove anything from the site that could distract the user. The user needs support to concentrate. No ads!
+      Remove anything from the site that could distract the user.
+      The user needs support to concentrate. No ads!
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      Introductory pages are useful for long forms. Use them to tell the user about: -- How long does is approx. take to fill in this form -- Does the user need any special information or documents he can prepare?
+      Introductory pages are useful for long forms.
+      Use them to tell the user about: -- How long does is approximately
+      take to fill in this form --
+      Does the user need any special information or documents he can prepare?
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      Set the right tab-order to enable fast input. Great UX is in the details.
+      Set the right tab-order to enable fast input.
+      Great UX is in the details.
 
 .hr
 
@@ -116,29 +137,38 @@ ul.checklist
       real-time updates designed to help people stay within necessary limits.
 
 p.paragraph.
-  These bits of feedback usually happen when people begin, continue, or stop entering answers within input fields.
+  These bits of feedback usually happen when people begin,
+  continue, or stop entering answers within input fields.
 
 h3.heading.heading--tertiary UX Checklist
 ul.checklist
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      Inline confirmations work best for questions with potentially high error rates, specific formatting requirements or actions like checking the availability of a username.
+      Inline confirmations work best for questions with potentially
+      high error rates, specific formatting requirements or
+      actions like checking the availability of a username.
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      Inline suggestions work best when there is a large set of valid answers people can pick from.
+      Inline suggestions work best when there is a large
+      set of valid answers people can pick from.
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      When validating people’s answers inline, do so after they have finished providing an answer, not during the process.
+      When validating people’s answers inline,
+      do so after they have finished providing an answer,
+      not during the process.
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      If you need to change people’s responses into a specific format, make sure you do so after they have finished providing an answer, not during the process.
+      If you need to change people’s responses into a specific format,
+      make sure you do so after they have finished providing an answer,
+      not during the process.
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      When input limits exist, communicate their boundaries using real-time, dynamic updates.
+      When input limits exist, communicate their boundaries using
+      real-time, dynamic updates.
 
 //- Copyright AXA Versicherungen AG 2015

--- a/docs/page/patterns/login.jade
+++ b/docs/page/patterns/login.jade
@@ -7,7 +7,9 @@ template: page.jade
 
 include ../components/includes/mixins.jade
 
-p.paragraph. Login forms are different from regular forms and follow specific guidelines.
+p.paragraph.
+  Login forms are different from regular forms
+  and follow specific guidelines.
 
 .toc
   .toc__title Table of contents
@@ -18,18 +20,23 @@ p.paragraph. Login forms are different from regular forms and follow specific gu
       a(href='#submit').toc__anchor-navigation__link Submit Buttons
 
 h2.heading.heading--secondary#simpleLogin Simple Login Form
-p.paragraph A login form consists of a username  / email and a password field, as well as a sign in button.
+
+p.paragraph
+  A login form consists of a username / email
+  and a password field, as well as a sign in button.
 
 h3.heading.heading--tertiary UX Checklist
 ul.checklist
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      Always give the user the possibility to retrieve his password if forgotten.
+      Always give the user the possibility to
+      retrieve his password if forgotten.
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      Follow web conventions so that password managers can store the username and password for the user.
+      Follow web conventions so that password managers can store
+      the username and password for the user.
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
@@ -37,7 +44,8 @@ ul.checklist
   li.checklist__item
     +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
     .checklist__item__content.
-      Don’t forget to give the user an easy way to register to your service.
+      Don’t forget to give the user an easy way
+      to register to your service.
 
 .hr
 

--- a/docs/page/patterns/spa.jade
+++ b/docs/page/patterns/spa.jade
@@ -8,7 +8,10 @@ template: page.jade
 include ../components/includes/mixins.jade
 
 p.paragraph.
-  A single-page application (SPA), is a web application or web site that fits on a single web page with the goal of providing a more fluid user experience akin to a desktop application.
+  A single-page application (SPA),
+  is a web application or web site that fits on
+  a single web page with the goal of providing a more
+  fluid user experience akin to a desktop application.
 
 .toc
   .toc__title Table of contents
@@ -29,63 +32,110 @@ p.paragraph.
       a(href='#animation').toc__anchor-navigation__link Animations & Transitions
 
 h2.heading.heading--secondary#seo SEO & Analytics
+
 p.paragraph.
-  Indexation of SPA can be difficult for search engines like google or analytics tools like AT Internet. Even though it is a technical task, discoverability is crucial for users coming from google and co.
+  Indexation of SPA can be difficult for search engines
+  like google or analytics tools like AT Internet.
+  Even though it is a technical task, discoverability
+  is crucial for users coming from google and co.
 
 .hr
 
 h2.heading.heading--secondary#performance Mobile Performance
+
 p.paragraph.
-  Again, a rather technical task - performance on mobile devices may suffer if too many interactions are about to happen on a page. Design thoughtfully and consider adding more interactions for desktops instead of removing them for mobile. Most importantly: Bring it up as early as possible in development.
+  Again, a rather technical task - performance on
+  mobile devices may suffer if too many interactions are
+  about to happen on a page. Design thoughtfully and consider
+  adding more interactions for desktops instead of removing them for mobile.
+  Most importantly: Bring it up as early as possible in development.
 
 .hr
 
 h2.heading.heading--secondary#back  Browser Back Button
+
 p.paragraph.
-  Single page applications should react to the browser back button as any other website would. Going back should be fast, reliable (data consistency) and not trigger unnecessary animations or effects. Remember: The back button is the single most used button in every web browser.
+  Single page applications should react to the browser back button
+  as any other website would. Going back should be fast,
+  reliable (data consistency) and not trigger unnecessary
+  animations or effects.
+  Remember: The back button is the single most used
+  button in every web browser.
 
 .hr
 
 h2.heading.heading--secondary#refresh Refresh & Links
+
 p.paragraph.
-  URLs are not automatically updated in single page applications. Additionally, if a link is shared or a url reloaded, the user expects to get to the current page.
+  URLs are not automatically updated in single page applications.
+  Additionally, if a link is shared or a url reloaded,
+  the user expects to get to the current page.
 
 .hr
 
 h2.heading.heading--secondary#feedback Instant Feedback
+
 p.paragraph.
-  Every actions creates a reaction. Users always need to know if the system is working properly. Feedback to actions should always start max. 0.1 seconds after the user took action (pressed a button for example).
+  Every actions creates a reaction. Users always need to know
+  if the system is working properly. Feedback to actions should
+    always start max. 0.1 seconds after the
+    user took action (pressed a button for example).
 
 .hr
 
 h2.heading.heading--secondary#spinner Load Spinners
+
 p.paragraph.
-  Load spinners tell a user that the site is  loading or rendering.
+  Load spinners tell a user that the site is loading or rendering.
 
 .hr
 
 h2.heading.heading--secondary#animation Animations & Transitions
+
 p.paragraph.
-  Moving elements are a powerful tool to attract and or waste users’ attention. When designing an animation consider its goal, its frequency of occurrence, and its mechanics.
-  Employ them sparingly and only when they add meaning to the interaction. Think about whether the animation will cause an attention shift or not and whether the same user is likely to stumble over it again and again. Will the animation reinforce relationships between UI elements? Will users trigger it directly or not? All these aspects matter in the design of a successful animation.
+  Moving elements are a powerful tool to attract and or
+  waste users’ attention.
+  When designing an animation consider its goal,
+  its frequency of occurrence, and its mechanics.
+  Employ them sparingly and only when they add meaning to the interaction.
+  Think about whether the animation will cause an attention shift or
+  not and whether the same user is likely to stumble over it again and again.
+  Will the animation reinforce relationships between UI elements?
+  Will users trigger it directly or not?
+  All these aspects matter in the design of a successful animation.
 
 h3.heading.heading--tertiary UX Checklist
+
 ul.checklist
-    li.checklist__item
-      +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
-      .checklist__item__content.
-        For an animation to effectively convey a cause-and-effect relationship between UI elements, the effect must begin within 0.1 seconds of the initial user action. This 0.1-second response time maintains the feeling of direct manipulation and supports the perception that the user action caused the new element to appear.
-    li.checklist__item
-      +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
-      .checklist__item__content.
-        Follow web conventions so that password managers can store the username and password for the user.
-    li.checklist__item
-      +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
-      .checklist__item__content.
-        Slower transitions are less likely to cause an attention shift and are thus less distracting. They are appropriate for animations indirectly triggered by the user or not user initiated in any way. In these situations, the new element should appear with little or no change in position to minimize distraction.
-    li.checklist__item
-      +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
-      .checklist__item__content.
-        Fast animations are more likely to attract attention when they happen outside the user’s focus of attention. They are suitable for important elements that users must attend to and act upon.
+  li.checklist__item
+    +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
+    .checklist__item__content.
+      For an animation to effectively convey a cause-and-effect
+      relationship between UI elements, the effect must begin
+      within 0.1 seconds of the initial user action.
+      This 0.1-second response time maintains the
+      feeling of direct manipulation and supports the
+      perception that the user action caused the new element to appear.
+  li.checklist__item
+    +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
+    .checklist__item__content.
+      Follow web conventions so that password managers can store
+      the username and password for the user.
+  li.checklist__item
+    +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
+    .checklist__item__content.
+      Slower transitions are less likely to cause an attention
+      shift and are thus less distracting.
+      They are appropriate for animations indirectly
+      triggered by the user or not user initiated in any way.
+      In these situations, the new element should appear with little or
+      no change in position to minimize distraction.
+  li.checklist__item
+    +svg('checkmark', ['checklist__item__icon', 'icon-svg'])
+    .checklist__item__content.
+      Fast animations are more likely to attract attention
+      when they happen outside the user’s focus of attention.
+      They are suitable for important elements that users must
+      attend to and act upon.
 
 //- Copyright AXA Versicherungen AG 2015

--- a/lib/marked-renderer-changelog.coffee
+++ b/lib/marked-renderer-changelog.coffee
@@ -8,11 +8,12 @@ renderer.heading = (text, level) ->
   l = 1 + parseInt level
   classes = []
   classes.push "heading", "heading--secondary" if l == 2
+  classes.push "heading", "heading--tertiary" if l == 3
   classes.push "changelog__timeline__item__content__headline" if l == 2
   joinedClasses = classes.join ' '
 
   [
-    "<h#{l} class=\"#{joinedClasses}\">\n"
+    "<h#{l} id=\"#{slug}\" class=\"#{joinedClasses}\">\n"
       "#{text}\n"
     "</h#{l}>\n"
   ].join ""

--- a/lib/marked-renderer.coffee
+++ b/lib/marked-renderer.coffee
@@ -15,10 +15,11 @@ renderer.heading = (text, level) ->
   l = 1 + parseInt level
   classes = []
   classes.push "heading", "heading--secondary" if l == 2
+  classes.push "heading", "heading--tertiary" if l == 3
   joinedClasses = classes.join ' '
 
   [
-    "<h#{l} class=\"#{joinedClasses}\">\n"
+    "<h#{l} id=\"#{slug}\" class=\"#{joinedClasses}\">\n"
       "#{text}\n"
     "</h#{l}>\n"
   ].join ""

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/style-guide",
   "version": "0.6.0",
-  "description": "AXA Switzerland Web Styleguide",
+  "description": "AXA Switzerland Web Style Guide",
   "keywords": [
     "axa",
     "switzerland",


### PR DESCRIPTION
This pr fixes all the `Styleguide`, `Design Guide`, `webstyleguide` words and replaces them with `Web Style Guide`. It also makes some improvements to text structure and our Markdown renderers.