### PR TITLE
Fix positioning and add progress container to example

### DIFF
--- a/docs/page/components/form-and-input-elements/snippets/progress-tracker.jade
+++ b/docs/page/components/form-and-input-elements/snippets/progress-tracker.jade
@@ -5,14 +5,16 @@ template: demo.jade
 
 include /components/includes/mixins.jade
 
-.progress-tracker
-  ul.progress-tracker__flow
-    li.progress-tracker__step.step.step--start.is-active
-      span.step__bullet 1
-    li.progress-tracker__step.step.is-active.is-current
-      span.step__bullet 2
-    li.progress-tracker__step.step.step--end
-      span.step__bullet
-        +svg('process-checkmark', 'step__bullet__checkmark')
+.progress-container
+  .progress-tracker.progress-container__progress
+    ul.progress-tracker__flow
+      li.progress-tracker__step.step.step--start.is-active
+        span.step__bullet 1
+      li.progress-tracker__step.step.is-active.is-current
+        span.step__bullet 2
+      li.progress-tracker__step.step.step--end
+        span.step__bullet
+          +svg('process-checkmark', 'step__bullet__checkmark')
+  span.progress-container__label Description
 
 //- Copyright AXA Versicherungen AG 2015

--- a/less/style/blocks/progress-container.less
+++ b/less/style/blocks/progress-container.less
@@ -2,8 +2,8 @@
 @import '../mixins/respond';
 
 .progress-container {
-  padding-bottom: 17px;
-  margin-top: 40px;
+  padding-bottom:45px;
+  margin-top: 0px;
 
   overflow: visible;
   background: @color-gray--lighter;

--- a/less/style/blocks/progress-tracker.less
+++ b/less/style/blocks/progress-tracker.less
@@ -2,6 +2,9 @@
   display: table;
   table-layout: fixed;
   width: 100%;
+
+  position: relative;
+  bottom: 15px;
 }
 
 .progress-tracker__flow {


### PR DESCRIPTION
Added the missing documentation for `progress-container` block.
Also changed the positioning of the `progress-tracker` block, so it works in AEM.