### PR TITLE
Use custom live reload port

### DIFF
--- a/tasks/serve.coffee
+++ b/tasks/serve.coffee
@@ -6,7 +6,9 @@ module.exports = (cb) ->
     .pipe webserver
       host: '0.0.0.0'
       port: process.env.PORT or 3000
-      livereload: true
+      livereload:
+        enable: true
+        port: 35730
       open: false
 
   # return nothin and don't call cb since this task runs "forever"


### PR DESCRIPTION
In order to prevent conflicts with other livereload-powered projects, I upped the default port.