### PR TITLE
Introduce Intercom, get rid of UserVoice

### DIFF
--- a/docs/layouts/page.jade
+++ b/docs/layouts/page.jade
@@ -170,11 +170,12 @@ html
             +displayMobileMenu(section)
 
     script.
+      var href = '#{relative(link)}'
       var mobile = $('[data-menu="sliding"]')
       
       var level = mobile
         .find('[data-link]')
-        .filter('[href="#{relative(link)}"]')
+        .filter('[href=\'' + href + '\']')
         .closest('[data-level]')
       
       if (level.length > 0) {

--- a/docs/layouts/page.jade
+++ b/docs/layouts/page.jade
@@ -102,35 +102,13 @@ html
     script(src=relative('/js/docs.all.min.js'))
     script(src="//www.google.com/jsapi?autoload={'modules':[{'name':'visualization','version':'1.1','packages':['corechart']}]}")
     
-    script.
-      // Set the locale for momentjs used in the datepicker
-      moment.locale('en_GB')
-          
-    script.
-      // Include the UserVoice JavaScript SDK (only needed once on a page)
-      UserVoice=window.UserVoice||[];
-      UserVoice.push(['set', {
-        accent_color: '#103184',
-        screenshot_enabled: false
-      }]);
-      (function(){
-        var uv=document.createElement('script');
-        uv.type='text/javascript';
-        uv.async=true;
-        uv.src='//widget.uservoice.com/O8ex403PfbC0GjKz3DuQ.js';
-        var s=document.getElementsByTagName('script')[0];
-        s.parentNode.insertBefore(uv,s)
-      })();
+    script moment.locale('en_GB')
 
   body.site
     .site__page
       #notification.notifications(data-notification-info=relative('/images/icons.svg#info')
         data-notification-success=relative('/images/icons.svg#checkmark')
         data-notification-error=relative('/images/icons.svg#cross'))
-      .l-container
-        .docs-floating-action
-          a(href='#feedback', data-uv-trigger).docs-floating-action__button.button.button--floating
-            +svg('feedback', ['button__icon', 'icon-svg'])
       header.header
         .header__meta
           .header__meta__content
@@ -191,7 +169,7 @@ html
           each section in navigation
             +displayMobileMenu(section)
 
-    script(type='text/javascript').
+    script.
       var mobile = $('[data-menu="sliding"]')
       
       var level = mobile
@@ -202,5 +180,8 @@ html
       if (level.length > 0) {
         mobile.slidingMenu('level', level)
       }
+    
+    script window.intercomSettings = { app_id: 'i82zr1ej' }
+    script (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/i82zr1ej';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
 
 //- Copyright AXA Versicherungen AG 2015


### PR DESCRIPTION
Have a look at [Intercom](https://www.intercom.io)'s Acquire module!

It's an amazing way to get and keep in touch with visitors. It's a full messaging experience integrated into the app. Apart from managing ordinary support queries, it also enables us to write to visitors or survey them.

This is what the visitor sees when he starts a new conversation:

![screen shot 2015-10-11 at 00 36 00](https://cloud.githubusercontent.com/assets/198988/10413596/29587d18-6fb0-11e5-95f2-697a7e9d851b.png)

Writing to the visitor, without him starting the converation:

![screen shot 2015-10-11 at 00 35 42](https://cloud.githubusercontent.com/assets/198988/10413597/30f801ce-6fb0-11e5-8abc-4a0e8ffc0a51.png)

List of conversations:

![screen shot 2015-10-11 at 00 34 53](https://cloud.githubusercontent.com/assets/198988/10413598/3909a99e-6fb0-11e5-9aa9-7618b7213d40.png)

Amazing thing, Intercom has a great mobile app and an even better web app!