### PR TITLE
Fix menu-main height

### DIFF
--- a/less/style/blocks/menu-main.less
+++ b/less/style/blocks/menu-main.less
@@ -40,7 +40,6 @@
 .menu-main__link {
   display: block;
 
-  height: 100%;
   padding: 0 20px 5px 20px;
 
   text-decoration: none;


### PR DESCRIPTION
This fixes a bug where the menu is too high. Weird is that the style guide docs itself were not affected.