### PR TITLE
Get rid of the sourceType module warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "autoprefixer-core": "~3.1.1",
     "babel-core": "^6.0.20",
+    "babel-preset-es2015": "^6.1.18",
     "babelify": "^6.1.2",
     "baconjs": "^0.7.73",
     "browserify": "^12.0.1",

--- a/tasks/docs-scripts.coffee
+++ b/tasks/docs-scripts.coffee
@@ -14,7 +14,9 @@ module.exports = (cb) ->
       debug: true,
       extensions: ['.js', '.coffee']
     })
-    .transform(babelify)
+    .transform(babelify, {
+      presets: ['es2015']
+    })
     .transform(coffeeify)
     .transform(shim)
     .add('docs/js/index.js')

--- a/tasks/scripts.coffee
+++ b/tasks/scripts.coffee
@@ -16,7 +16,9 @@ module.exports = (cb) ->
       debug: true,
       extensions: ['.js', '.coffee']
     })
-    .transform(babelify)
+    .transform(babelify, {
+      presets: ['es2015']
+    })
     .transform(coffeeify)
     .transform(shim)
     .add('jquery/index.js')


### PR DESCRIPTION
Had this warning message with node `v5`:

```sh
[16:10:21] Parsing file docs/js/index.js: 'import' and 'export' may appear only with 'sourceType: module' (1:0)
```

The problem here, scripts weren't built correctly and broke all our interactivity.

Got rid of it adding the ES2015 preset to babel(ify).