### PR TITLE
#427 remove empty clickable area in logo.

### DIFF
--- a/docs/layouts/page.jade
+++ b/docs/layouts/page.jade
@@ -129,12 +129,13 @@ html
                 each page in navigation
                   li.menu-main__item(class={ 'is-active': isActive(page) })
                     a.menu-main__link(class={ 'is-active': isActive(page) }, href=relative(page.link))= page.title
-              a.header__main__item.header__main__item--mobile-action.site__burger(data-burger, href="#")
-                svg.icon.burger-icon(data-burger)
-                  g(stroke="currentColor", stroke-width="2", fill="none", fill-rule="evenodd")
-                    path(d="M0,5 L24,5", class="burger-icon__top")
-                    path(d="M0,12 L24,12", class="burger-icon__middle")
-                    path(d="M0,19 L24,19", class="burger-icon__bottom")
+              .header__main__item.header__main__item--mobile-actions.mobile-actions
+                a.mobile-actions__item.site__burger(data-burger, href="#")
+                  svg.mobile-actions__icon.icon.burger-icon(data-burger)
+                    g(stroke="currentColor", stroke-width="2", fill="none", fill-rule="evenodd")
+                      path.burger-icon__top(d="M0,5 L24,5")
+                      path.burger-icon__middle(d="M0,12 L24,12")
+                      path.burger-icon__bottom(d="M0,19 L24,19")
 
       .page-content
         if section

--- a/docs/page/components/snippets/header.jade
+++ b/docs/page/components/snippets/header.jade
@@ -57,13 +57,15 @@ header.header
             a.menu-main__link(href="#") Menu Item 3
           li.menu-main__item
             a.menu-main__link(href="#") Menu Item 4
-        a.header__main__item.header__main__item--mobile-action(href="#")
-          +svg('search', ['header__main__mobile-icon', 'icon'])
-        a.header__main__item.header__main__item--mobile-action.site__burger(data-burger, href="#")
-          svg.icon.burger-icon(data-burger)
-            g(stroke="currentColor", stroke-width="2", fill="none", fill-rule="evenodd")
-              path(d="M0,5 L24,5", class="burger-icon__top")
-              path(d="M0,12 L24,12", class="burger-icon__middle")
-              path(d="M0,19 L24,19", class="burger-icon__bottom")
+        
+        .header__main__item.header__main__item--mobile-actions.mobile-actions
+          a.mobile-actions__item(href="#")
+            +svg('search', ['mobile-actions__icon', 'icon'])
+          a.mobile-actions__item.site__burger(data-burger, href="#")
+            svg.mobile-actions__icon.icon.burger-icon(data-burger)
+              g(stroke="currentColor", stroke-width="2", fill="none", fill-rule="evenodd")
+                path.burger-icon__top(d="M0,5 L24,5")
+                path.burger-icon__middle(d="M0,12 L24,12")
+                path.burger-icon__bottom(d="M0,19 L24,19")
 
 //- Copyright AXA Versicherungen AG 2015

--- a/docs/page/inspiration/pages/test.jade
+++ b/docs/page/inspiration/pages/test.jade
@@ -73,7 +73,6 @@ html
             .header__main__row
               a.header__main__item.header__main__item--brand.brand(href="#")
                 .brand__logo
-                .brand__tagline.brand__tagline--de
               ul.header__main__item.header__main__item--menu.menu-main(data-menu="main")
                 li.menu-main__item.is-active(data-item)
                   a.menu-main__link.is-active(href="#", data-link) Versicherungen & Mehr

--- a/docs/page/inspiration/pages/test.jade
+++ b/docs/page/inspiration/pages/test.jade
@@ -124,14 +124,16 @@ html
                 li.menu-main__item(data-item)
                   a.menu-main__link(href="#", data-link) Kundenportale
                   .menu-main__panel(data-panel) Kundenportale
-              a.header__main__item.header__main__item--mobile-action(href="#")
-                +svg('search', ['header__main__mobile-icon', 'icon'])
-              a.header__main__item.header__main__item--mobile-action.site__burger(data-burger, href="#")
-                svg.icon.burger-icon(data-burger)
-                  g(stroke="currentColor", stroke-width="2", fill="none", fill-rule="evenodd")
-                    path(d="M0,5 L24,5", class="burger-icon__top")
-                    path(d="M0,12 L24,12", class="burger-icon__middle")
-                    path(d="M0,19 L24,19", class="burger-icon__bottom")
+              
+              .header__main__item.header__main__item--mobile-actions.mobile-actions
+                a.mobile-actions__item(href="#")
+                  +svg('search', ['mobile-actions__icon', 'icon'])
+                a.mobile-actions__item.site__burger(data-burger, href="#")
+                  svg.mobile-actions__icon.icon.burger-icon(data-burger)
+                    g(stroke="currentColor", stroke-width="2", fill="none", fill-rule="evenodd")
+                      path.burger-icon__top(d="M0,5 L24,5")
+                      path.burger-icon__middle(d="M0,12 L24,12")
+                      path.burger-icon__bottom(d="M0,19 L24,19")
 
       .page-content
         .row

--- a/less/style.less
+++ b/less/style.less
@@ -63,6 +63,7 @@
 @import './style/blocks/menu';
 @import './style/blocks/meta-language';
 @import './style/blocks/meta-menu';
+@import './style/blocks/mobile-actions';
 @import './style/blocks/mobile-languages';
 @import './style/blocks/mobile-menu';
 @import './style/blocks/mobile';

--- a/less/style/blocks/header.less
+++ b/less/style/blocks/header.less
@@ -124,30 +124,13 @@
   });
 }
 
-.header__main__item--mobile-action {
+.header__main__item--mobile-actions.mobile-actions {
   order: 4;
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 @grid-gutter-width/2;
-
-  color: @color-black;
-  cursor: pointer;
-
-  z-index: 10000;
-
-  &:hover {
-    color: @color-blue;
-  }
+  padding: 0;
 
   .respond(large, {
     display: none;
   });
-}
-
-.header__main__mobile-icon {
-  display: block;
 }
 
 // Copyright AXA Versicherungen AG 2015

--- a/less/style/blocks/header.less
+++ b/less/style/blocks/header.less
@@ -50,6 +50,10 @@
   height: 100%;
 }
 
+.header__main__row {
+  justify-content: space-between;
+}
+
 .header__meta__item {
   .make-column();
 
@@ -104,7 +108,6 @@
 
 .header__main__item--brand.brand {
   order: 1;
-  flex-grow: 1;
   align-self: center;
 }
 

--- a/less/style/blocks/mobile-actions.less
+++ b/less/style/blocks/mobile-actions.less
@@ -1,0 +1,29 @@
+@import '../variables';
+@import '../mixins/respond';
+
+.mobile-actions {
+  display: flex;
+}
+
+.mobile-actions__item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 @grid-gutter-width/2;
+
+  color: @color-black;
+  cursor: pointer;
+
+  z-index: @z-index-burger-icon;
+
+  &:hover,
+  &:focus {
+    color: @color-blue;
+  }
+}
+
+.mobile-actions__icon {
+  display: block;
+}
+
+// Copyright AXA Versicherungen AG 2015

--- a/less/style/variables.less.lodash
+++ b/less/style/variables.less.lodash
@@ -139,7 +139,8 @@ _.forEach(colors.tbd, function (colorCode, colorName) {
 @z-index-site-page-masked: 9961;
 @z-index-example-header: 9970;
 @z-index-backdrop: 9980;
-@z-index-backdrop-content: 9981;
+@z-index-burger-icon: 9981;
+@z-index-backdrop-content: 9982;
 @z-index-modal-wrapper: 9998;
 @z-index-modal: 9999;
 


### PR DESCRIPTION
The whitespace of the logo spanned the whole empty area in the header. This meant that when you clicked into that white area, you got directed to the homepage. People however aren't used that clicks on empty areas trigger actions, so we needed to get rid of that. Fixes #427

Update @davidknezic:

This is the new markup structure for the mobile actions in the header:

```jade
.header__main__item.header__main__item--mobile-actions.mobile-actions
  a.mobile-actions__item(href="#")
    +svg('search', ['mobile-actions__icon', 'icon'])
  a.mobile-actions__item.site__burger(data-burger, href="#")
    svg.mobile-actions__icon.icon.burger-icon(data-burger)
      g(stroke="currentColor", stroke-width="2", fill="none", fill-rule="evenodd")
        path.burger-icon__top(d="M0,5 L24,5")
        path.burger-icon__middle(d="M0,12 L24,12")
        path.burger-icon__bottom(d="M0,19 L24,19")
```