### PR TITLE
Add focus state to info icon

### DIFF
--- a/docs/page/components/form-and-input-elements/snippets/form-group.jade
+++ b/docs/page/components/form-and-input-elements/snippets/form-group.jade
@@ -20,13 +20,13 @@ include /components/includes/mixins.jade
   .form__group
     .form__group__label
       .form__group__label__info-icon
-        .info-icon(data-info, data-target='#target')
+        a.info-icon(data-info, area-describedby='#target', data-target='#target', href='#', role='button')
           +svg('info', 'info-icon__svg')
           +svg('close', ['info-icon__svg', 'info-icon__svg--close'])
       .form__group__label__info-icon-text-wrapper Form group with info
     .form__group__control
       input(type='text').control.control--input
-      .form__info-text(style='display: none;')#target
+      .form__info-text(style='display: none;', role='tooltip')#target
         .info-text
           p.paragraph Some meaningful explanation may be placed here
   .form__group

--- a/jquery/info.coffee
+++ b/jquery/info.coffee
@@ -15,8 +15,6 @@ class Info
     @$element.on 'click', @, (event) ->
       event.data.toggle event
 
-    @$target.slideToggle()
-
   toggle: () ->
     @$target.slideToggle()
     @$element.toggleClass 'is-active'

--- a/less/style/blocks/info-icon.less
+++ b/less/style/blocks/info-icon.less
@@ -8,8 +8,14 @@
 
   display: block;
 
-  &:hover {
+  &:hover,
+  &:focus {
     cursor: pointer;
+    outline: none;
+
+    .info-icon__svg {
+      fill: @color-blue;
+    }
   }
 
   &.is-active {


### PR DESCRIPTION
Add a the focus state to our info icon! :tada: 

<img width="465" alt="screen shot 2015-12-18 at 14 28 37" src="https://cloud.githubusercontent.com/assets/198988/11897894/b7d3057c-a593-11e5-8547-a394ae9a20eb.png">
