### PR TITLE
adding a mixin for 'custom' min-width media queries.

### DIFF
--- a/less/style/mixins/respond.less
+++ b/less/style/mixins/respond.less
@@ -22,4 +22,10 @@
   }
 }
 
+.respond(@bp; @rules) {
+  @media (min-width: @bp) {
+    @rules();
+  }
+}
+
 // Copyright AXA Versicherungen AG 2015


### PR DESCRIPTION
to support writing custom min-width media queries with a less mixin, i propose this addition.

usage:
```
.selector {
  height: 5rem;
  .respond(30rem, {
    height: 10rem;
  });
}
```