### PR TITLE
Improve Docker build times

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git/
+dist/
+node_modules/
+tmp/
+.DS_Store/
+.gitignore
+.npmignore
+.travis.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM node:onbuild
+FROM node:5-slim
 EXPOSE 3000
 
-ENV GITHUB_USERNAME ''
-ENV GITHUB_PASSWORD ''
+# Will unfortunately have to keep this as long as
+# we have git deps in package.json
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+	&& rm -rf /var/lib/apt/lists/*
 
-CMD ./node_modules/.bin/gulp build && ./node_modules/.bin/gulp serve
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+RUN npm install --quiet
+COPY . /usr/src/app
+
+RUN npm run build
+
+CMD [ "npm", "start" ]

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "dev": "./node_modules/.bin/gulp dev",
     "build": "./node_modules/.bin/gulp build",
-    "start": "./node_modules/.bin/gulp build && ./node_modules/.bin/gulp serve"
+    "start": "./node_modules/.bin/gulp serve"
   },
   "author": "AXA Versicherungen AG",
   "license": "SEE LICENSE IN LICENSE",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "gulp-less": "^3.0.3",
     "gulp-load-tasks": "^0.8.4",
     "gulp-modernizr": "0.0.0",
-    "gulp-ng-annotate": "^0.5.2",
     "gulp-plumber": "^1.0.0",
     "gulp-postcss": "~2.0.0",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
So long, no pr. Let's start again!

We're currently facing quite long Docker build times, usually around 10 minutes. That's pretty long compared to the short build times locally.

On my quest to improve that, I made some changes:

* [x] added `.dockerignore`, especially ignoring the `.git` folder which is 1.4gb!!
* [x] changed to use the `node:slim` base image, installing `git` manually

... there's still a lot of potential, here's what makes sense next:

* [ ] remove obsolete npm deps
* [ ] move psds and illustrator files (~50mb) to a cdn
* [ ] get rid of all these git dependencies, so there's no need to install git and it saves fetching time

... and ultimately there's [these performance problems](https://github.com/npm/npm/issues/8826) with `npm@3` that still don't seem to be resolved.