### PR TITLE
Leave sources in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,5 @@
 dist/docs/
 docs/
-icons/
-images/
-jquery/
-less/
 lib/
 tasks/
 tmp/
@@ -11,4 +7,3 @@ tmp/
 coffeelint.json
 Dockerfile
 gulpfile.coffee
-modernizr.json

--- a/less/style/variables.less
+++ b/less/style/variables.less
@@ -1,5 +1,3 @@
-// Attention: This file is generated automatically!
-
 // #############################
 // # Grid
 // #############################
@@ -93,34 +91,47 @@
 // #############################
 
 // Primary colors
-<%
-_.forEach(colors.primary, function (colorCode, colorName) {
-%>
-@color-<%= colorName %>: <%= colorCode %>;<%
-});
-%>
+
+@color-blue: #103184;
+@color-red: #ff1821;
 
 // Secondary colors
-<%
-_.forEach(colors.secondary, function (colorGroup) {
-%>
-// <%= colorGroup.name %>
-<%
-  _.forEach(colorGroup.colors, function(colorCode, colorName) {
-%>
-@color-<%= colorName %>: <%= colorCode %>;<%
-  });
-%>
-<%
-}); %>
+
+@color-light-blue--light: #5c91c0;
+@color-light-blue: #0062a9;
+@color-green: #7a9f35;
+@color-blue-gray--light: #dedee2;
+@color-blue-gray: #79838d;
+
+@color-white: #ffffff;
+@color-gray--lighter: #efefef;
+@color-gray--light: #e5e5e5;
+@color-gray--mid: #dadada;
+@color-gray: #b0b0b0;
+@color-gray--dark: #919191;
+@color-gray--darker: #6f6f6f;
+@color-gray--predarkest: #666666;
+@color-gray--darkest: #333333;
+@color-black: #000000;
+
 
 // TBD colors
-<%
-_.forEach(colors.tbd, function (colorCode, colorName) {
-%>
-@color-<%= colorName %>: <%= colorCode %>;<%
-});
-%>
+
+@color-tbd-4: #a5afcb;
+@color-tbd-5: #eff4f9;
+@color-tbd-6: #dde8f2;
+@color-tbd-7: #12369d;
+@color-tbd-8: #e0e0e0;
+@color-tbd-9: #22336a;
+@color-tbd-10: #040b20;
+@color-tbd-11: #131f44;
+@color-tbd-12: #f3f6fc;
+@color-tbd-13: #4f5d88;
+@color-tbd-16: #f2f2f2;
+@color-tbd-17: #dfdfdf;
+@color-tbd-23: #1762a5;
+@color-tbd-24: #010943;
+@color-tbd-25: #babfd3;
 
 // #############################
 // # z-index


### PR DESCRIPTION
We'd like to use the original js sources for our axa.ch build instead of only the compiled ones. That way, we'll be able to include the files using `require('@axa-ch/stye-guide')`. That works, because our `package.json` references `jquery/index.js` as entry point of the package.

Also, in order to resolve the bower issue #439, this pr gets rid of `lodash` in our `less` directory. No precompilation necessary anymore.