### PR TITLE
Make chips more beautiful

### DIFF
--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -26,3 +26,7 @@ $('#showNotification').on('click', function () {
     html: isHtml
   })
 })
+
+$('#cities-autocomplete').autocomplete({
+  source: ['8000 Zürich', '8400 Winterthur', '8472 Seuzach']
+})

--- a/docs/page/components/form-and-input-elements/snippets/textfield-autocomplete.jade
+++ b/docs/page/components/form-and-input-elements/snippets/textfield-autocomplete.jade
@@ -10,10 +10,6 @@ template: demo.jade
         .form__group__label__text Form label
       .form__group__control
         .autocomplete
-          input#cities-autocomplete.control.control--input(type='text')
-
-script.
-  $('#cities-autocomplete').autocomplete({
-    source: ['8000 Zürich', '8400 Winterthur', '8472 Seuzach']});
+          input#cities-autocomplete.control.control--input(type='text', autocomplete="off")
 
 //- Copyright AXA Versicherungen AG 2015

--- a/docs/page/components/form-and-input-elements/snippets/textfield-chips.jade
+++ b/docs/page/components/form-and-input-elements/snippets/textfield-chips.jade
@@ -25,7 +25,7 @@ include /components/includes/mixins.jade
               .chips__chip__text Test
               a.chips__chip__close-button(href='#')
                 +svg('cross', ['chips__chip__close-button__icon', 'icon'])
-            input.chips__input
+            input.chips__input(placeholder="add more...")
           .chips__autocomplete.autocomplete__suggestions
             .autocomplete__suggestions__item 8400 Winterthur
             .autocomplete__suggestions__item 8472 Seuzach

--- a/less/style/blocks/chips.less
+++ b/less/style/blocks/chips.less
@@ -33,78 +33,51 @@
 }
 
 .chips__chip {
-  position: relative;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
 
-  height: 34px;
-  line-height: 34px;
-  padding-right: 2.2em;
+  height: 2rem;
 
   margin-top: 4px;
   margin-left: 5px;
 
   background: @color-gray--dark;
-
-  .respond(medium, {
-      height: 30px;
-      line-height: 30px;
-      padding-right: 1.8em;
-    });
 }
 
 .chips__chip__text {
-  display: inline-block;
-  padding-left: 15px;
+  .make-font-medium();
+
+  flex-grow: 1;
+  padding-left: 1rem;
 
   color: @color-white;
-
-  .respond(medium, {
-    padding-left: 10px;
-  });
 }
 
 .chips__chip__close-button {
-  position: absolute;
-
-  top: 0;
-  bottom: 0;
-  right: 0;
-
-  display: block;
-  width: 2.2em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 1.8em;
+  height: 100%;
 
   text-align: center;
-  color: @color-gray--lighter;
-
-  .respond(medium, {
-    width: 1.8em;
-  });
+  color: @color-gray--light;
 
   &:hover {
-    color: @color-gray--darker;
+    color: @color-white;
   }
 }
 
-.chips__chip__close-button__icon {
-  display: inline-block;
-
-  height: 1.1em;
-  width: 1.1em;
-
-  // To make the icon vertically centered
-  margin-top: 8px;
-
-  .respond(medium, {
-    height: 0.9em;
-    width: 0.9em;
-    margin-top: 8px;
-  });
+.chips__chip__close-button__icon.icon {
+  display: block;
+  height: 1rem;
+  width: 1rem;
 }
 
 .chips__input {
-  border: none;
-  margin-left: 10px;
+  margin: 0.5rem;
 
+  border: none;
   background: transparent;
 
   &:focus {
@@ -112,4 +85,4 @@
   }
 }
 
-// Copyright AXA Versicherungen AG 2015
+// Copyright AXA Versicherungen AG 2016


### PR DESCRIPTION
Fixed the styling of our chips component, so they look like this. No markup is changed.

<img width="367" alt="screen shot 2016-03-09 at 17 18 34" src="https://cloud.githubusercontent.com/assets/198988/13641993/01501682-e61b-11e5-9d11-e5e4c69404bc.png">

This fixes #448. Do you think we can merge this @martinoss?