### PR TITLE
Bugfix/add reboot file

### DIFF
--- a/less/style/blocks/reboot.less
+++ b/less/style/blocks/reboot.less
@@ -1,0 +1,13 @@
+@import '../mixins/font.less';
+
+h1 {
+  .make-font-heading-primary();
+}
+
+h2 {
+  .make-font-heading-secondary();
+}
+
+h3 {
+  .make-font-heading-tertiary();
+}

--- a/less/style/blocks/reboot.less
+++ b/less/style/blocks/reboot.less
@@ -1,4 +1,9 @@
 @import '../mixins/font.less';
+@import '../mixins/make-link.less';
+
+a {
+  .make-link();
+}
 
 h1 {
   .make-font-heading-primary();

--- a/less/style/blocks/reboot.less
+++ b/less/style/blocks/reboot.less
@@ -16,3 +16,7 @@ h2 {
 h3 {
   .make-font-heading-tertiary();
 }
+
+p {
+  .make-font-large();
+}


### PR DESCRIPTION
fixes #487 

At the moment the default styling for our `<h1>` to `<h6>`, `<p>`, `<a>` and more is gained from the User Agent style sheet. Which is what we want for our BEM blocks, but as soon as WYSIWYG-Editor`s generated markup comes into play we loose our unique, granular styling possibility gained through BEM.

Therefor we (me and dave) decided to adopt - from [Bootstrap 4](http://v4-alpha.getbootstrap.com/content/reboot/) - a `reboot.less` file which aims to set default CSS properties for typography, dimension and distance.