### PR TITLE
enabled mqpacker's intrinsic sort feature

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -29,7 +29,7 @@ export default (glob, paths, dest) =>
       '!**/*.map',
     ]))
     .pipe(postcss([
-      cssmqpacker(),
+      cssmqpacker({ sort: true }),
       csswring(),
     ]))
     .pipe(rename({ extname: '.min.css' }))


### PR DESCRIPTION
fixes #507 

Our CSS-MQ-Packer PostCSS plugin messes up the order (specifity/precendence) of media queries. This cause wrong styles being applied by the browser.

Can be fixed with [MQ-Packer's intrinsic sort feature](https://github.com/hail2u/node-css-mqpacker#sort)

**Example:**

```less
.test {
  display:block;
  width: 100px;
  height: 500px;
  background: yellow;

  .respond(25rem, {
    background: green;
  });

  .respond(medium, {
    background: blue;
  });
}
```

**Expected CSS:**

```css
.test {
  display:block;
  width: 100px;
  height: 500px;
  background: yellow;
}

@media (min-width: 25rem) {
  .test {
    background: green;
  }
}

@media (min-width: 768px) {
  .test {
    background: blue;
  }
}
```

**Generated CSS:**

```css
.test {
  display:block;
  width: 100px;
  height: 500px;
  background: yellow;
}

@media (min-width: 768px) {
  .test {
    background: blue;
  }
}

@media (min-width: 25rem) {
  .test {
    background: green;
  }
}
```