### PR TITLE
Extend capabilities of the side nav

### DIFF
--- a/docs/page/components/site.jade
+++ b/docs/page/components/site.jade
@@ -10,24 +10,37 @@ include ./includes/mixins.jade
   Whenever there's a hierarchy of components, there needs to be an upmost
   element. The Site component is exactly that element.
   
-  This component splits the web app into a *content* and *mobile menu* part.
-  The *content* is fully visible by default. Whenever the menu
-  gets toggled it almost completely pushes the *content* away
-  from the visible area in favour of the *mobile menu*.
+  Additionally, the Site component helps split the page into a content and
+  a side navigation part.
 
-aside.callout
-  h2.callout__heading Most functionality on mobile only!
-  :markdown
-    Since we use easier ways of navigation on larger viewports, the
-    *mobile menu* isn't available on any other than small viewports.
+.toc
+  .toc__title Table of contents
+  ul.toc__anchor-navigation
+    li.toc__anchor-navigation__item
+      a.toc__anchor-navigation__link(href='#default') Default
+    li.toc__anchor-navigation__item
+      a.toc__anchor-navigation__link(href='#left-menu') Left Menu
+    li.toc__anchor-navigation__item
+      a.toc__anchor-navigation__link(href='#stacked-menu') Stacked Menu
+    li.toc__anchor-navigation__item
+      a.toc__anchor-navigation__link(href='#desktop-visibility') Desktop Visibility
+    li.toc__anchor-navigation__item
+      a.toc__anchor-navigation__link(href='#fixed-menu') Fixed Menu
+
+h2.heading.heading--secondary#default Default
+
+p.paragraph.
+  In the default state of the Site component, the side navigation
+  only exists on mobile viewports. On those devices, the navigation slides
+  into the visible area from the right, pushing the page content away.
 
 +example('/components/demos/site.html', { minHeight: '400', disableDesktop: true })
 
 .toggle
-  .toggle__button(data-info, data-target='#progressbar-code')
+  .toggle__button(data-info, data-target='#code')
     +svg('source', ['icon', 'toggle__icon'])
     span See code
-  .toggle__content#progressbar-code
+  .toggle__content#code
     .tab-panel(data-tab, data-tab-default='html')
       .tab-panel__header
         .tab-panel__header__tabs
@@ -41,6 +54,8 @@ aside.callout
               .checklist__item__content.
                 If possible, add the <code class="code">site</code>
                 block to the <code class="code">body</code> element.
+                If this is impossible, make sure all parents span across
+                100% of the page's height.
             li.checklist__item
               +svg('checkmark', ['checklist__item__icon', 'icon'])
               .checklist__item__content.
@@ -77,5 +92,38 @@ aside.callout
             // Hide it
             $('.site').site('hideMenu')
             ```
+            
+h2.heading.heading--secondary#left-menu Left Menu
+
+p.paragraph.
+  Using the #[code.code site--left] modifier, the location of the side navigation can be
+  flipped to the left.
+
++example('/components/demos/site-left.html', { disableDesktop: true })
+
+h2.heading.heading--secondary#stacked-menu Stacked Menu
+
+p.paragraph.
+  If it's desired that the content area doesn't get pushed away, the
+  #[code.code site--stacked] modifier can be applied to the Site component.
+
++example('/components/demos/site-stacked.html', { disableDesktop: true })
+
+h2.heading.heading--secondary#desktop-visibility Desktop Visibility
+
+p.paragraph.
+  In some cases, a side navigation is preferred even on desktop
+  viewports. In that case the #[code.code site--desktop] modifier can be used.
+
++example('/components/demos/site-desktop.html')
+
+h2.heading.heading--secondary#fixed-menu Fixed Menu
+
+p.paragraph.
+  Sometimes it's desired to have the side navigation available on
+  desktop and make it visible all the time. This is what the
+  #[code.code site--fixed] modifier is for.
+
++example('/components/demos/site-fixed.html')
 
 //- Copyright AXA Versicherungen AG 2015

--- a/docs/page/components/site.jade
+++ b/docs/page/components/site.jade
@@ -34,7 +34,7 @@ p.paragraph.
   only exists on mobile viewports. On those devices, the navigation slides
   into the visible area from the right, pushing the page content away.
 
-+example('/components/demos/site.html', { minHeight: '400', disableDesktop: true })
++example('/components/demos/site.html', { disableDesktop: true })
 
 .toggle
   .toggle__button(data-info, data-target='#code')

--- a/docs/page/components/snippets/site-desktop.jade
+++ b/docs/page/components/snippets/site-desktop.jade
@@ -1,0 +1,16 @@
+---
+title: Desktop Site
+template: demo.jade
+---
+
+include /components/includes/mixins.jade
+
+.site.site--desktop(data-site)
+  .site__page(data-page)
+    .site__page__mask(data-mask)
+    p.paragraph
+      a.button.button--primary(href="#", data-burger) Open Menu
+  .site__mobile(data-mobile)
+    a.button.button--secondary(href="#", data-burger) Close Menu
+
+//- Copyright AXA Versicherungen AG 2015

--- a/docs/page/components/snippets/site-fixed.jade
+++ b/docs/page/components/snippets/site-fixed.jade
@@ -5,7 +5,7 @@ template: demo.jade
 
 include /components/includes/mixins.jade
 
-.site.site--fixed(data-site)
+.site.site--fixed.site--left(data-site)
   .site__page(data-page)
     .site__page__mask(data-mask)
     p.paragraph

--- a/docs/page/components/snippets/site-fixed.jade
+++ b/docs/page/components/snippets/site-fixed.jade
@@ -1,0 +1,22 @@
+---
+title: Fixed Menu Site
+template: demo.jade
+---
+
+include /components/includes/mixins.jade
+
+.site.site--fixed(data-site)
+  .site__page(data-page)
+    .site__page__mask(data-mask)
+    p.paragraph
+      a.link(href="#", data-burger) Open Menu
+    p.paragraph.
+      Opening only works on mobile.
+  .site__mobile(data-mobile)
+    p.paragraph
+      a.link(href="#", data-burger) Close Menu
+    p.paragraph.
+      Closing only works on mobile.
+    
+
+//- Copyright AXA Versicherungen AG 2015

--- a/docs/page/components/snippets/site-left.jade
+++ b/docs/page/components/snippets/site-left.jade
@@ -1,0 +1,19 @@
+---
+title: Left Menu Site
+template: demo.jade
+---
+
+include /components/includes/mixins.jade
+
+.site.site--left(data-site)
+  .site__page(data-page)
+    .site__page__mask(data-mask)
+    p.paragraph.
+      Make sure you switch to one of the smaller viewports to see
+      the mobile menu in action.
+    p.paragraph
+      a.button.button--primary(href="#", data-burger) Open Mobile Menu
+  .site__mobile(data-mobile)
+    a.button.button--secondary(href="#", data-burger) Close Mobile Menu
+
+//- Copyright AXA Versicherungen AG 2015

--- a/docs/page/components/snippets/site-stacked.jade
+++ b/docs/page/components/snippets/site-stacked.jade
@@ -1,0 +1,19 @@
+---
+title: Stacked Menu Site
+template: demo.jade
+---
+
+include /components/includes/mixins.jade
+
+.site.site--stacked(data-site)
+  .site__page(data-page)
+    .site__page__mask(data-mask)
+    p.paragraph.
+      Make sure you switch to one of the smaller viewports to see
+      the mobile menu in action.
+    p.paragraph
+      a.button.button--primary(href="#", data-burger) Open Mobile Menu
+  .site__mobile(data-mobile)
+    a.button.button--secondary(href="#", data-burger) Close Mobile Menu
+
+//- Copyright AXA Versicherungen AG 2015

--- a/less/style/blocks/site.less
+++ b/less/style/blocks/site.less
@@ -81,6 +81,8 @@
   z-index: @z-index-site-mobile-nav;
   overflow-y: scroll;
 
+  background-color: @color-white;
+
   transition: transform @transition-duration @transition-fn-fancy;
 }
 
@@ -138,18 +140,6 @@
     });
   }
 
-  .site__page.is-pushed {
-    .respond(large, {
-      transform: translateX(-@mobile-nav-width);
-    });
-  }
-
-  &.site--left {
-    .site__page.is-pushed {
-      transform: translateX(@mobile-nav-width);
-    }
-  }
-
   &.site--stacked {
     .site__page.is-pushed {
       transform: translateX(0);
@@ -168,6 +158,20 @@
     .respond(large, {
       transform: translateX(0);
     });
+  }
+}
+
+.site--desktop {
+  .site__page.is-pushed {
+    .respond(large, {
+      transform: translateX(-@mobile-nav-width);
+    });
+  }
+
+  &.site--left {
+    .site__page.is-pushed {
+      transform: translateX(@mobile-nav-width);
+    }
   }
 }
 
@@ -202,7 +206,8 @@
       transform: translateX(0);
     }
 
-    &.site--left .site__page {
+    &.site--left .site__page,
+    &.site--left .site__page.is-pushed {
       padding-left: @mobile-nav-width-fixed;
       padding-right: 0;
       transform: translateX(0);
@@ -214,6 +219,7 @@
     }
 
     .site__mobile {
+      width: @mobile-nav-width-fixed;
       transform: translateX(0);
       border-left: 1px solid @color-gray--light;
     }

--- a/less/style/blocks/site.less
+++ b/less/style/blocks/site.less
@@ -101,4 +101,70 @@
   }
 }
 
+.site--left {
+  .site__page.is-pushed {
+    transform: translateX(@mobile-nav-width);
+  }
+
+  .site__mobile {
+    left: 0;
+    right: auto;
+    transform: translateX(-100%);
+  }
+
+  .site__mobile.is-visible {
+    transform: translateX(0);
+
+    .respond(large, {
+      transform: translateX(-100%);
+    });
+  }
+}
+
+.site--stacked {
+  .site__page.is-pushed {
+    transform: translateX(0);
+  }
+}
+
+.site--desktop {
+  .site.is-mobile-nav-open {
+    .respond(large, {
+      overflow-y: hidden;
+    });
+  }
+
+  .site__page.is-pushed {
+    .respond(large, {
+      transform: translateX(-@mobile-nav-width);
+    });
+  }
+
+  &.site--left {
+    .site__page.is-pushed {
+      transform: translateX(@mobile-nav-width);
+    }
+  }
+
+  &.site--stacked {
+    .site__page.is-pushed {
+      transform: translateX(0);
+    }
+  }
+
+  .site__page__mask.is-visible {
+    .respond(large, {
+      opacity: 0.5;
+      pointer-events: all;
+      height: 100%;
+    });
+  }
+
+  .site__mobile.is-visible {
+    .respond(large, {
+      transform: translateX(0);
+    });
+  }
+}
+
 // Copyright AXA Versicherungen AG 2015

--- a/less/style/blocks/site.less
+++ b/less/style/blocks/site.less
@@ -3,6 +3,7 @@
 @import '../mixins/respond';
 
 @mobile-nav-width: 80%;
+@mobile-nav-width-fixed: 300px;
 
 .site {
   overflow-x: hidden;
@@ -22,7 +23,9 @@
   right: 0;
   overflow: hidden;
 
-  transition: transform @transition-duration @transition-fn-fancy;
+  transition: transform @transition-duration @transition-fn-fancy,
+    padding-left @transition-duration @transition-fn-fancy,
+    padding-right @transition-duration @transition-fn-fancy;
 }
 
 .site__page.is-pushed {
@@ -127,7 +130,8 @@
   }
 }
 
-.site--desktop {
+.site--desktop,
+.site--fixed {
   .site.is-mobile-nav-open {
     .respond(large, {
       overflow-y: hidden;
@@ -165,6 +169,60 @@
       transform: translateX(0);
     });
   }
+}
+
+.site--fixed {
+  .site__mobile {
+    width: @mobile-nav-width-fixed;
+  }
+
+  .site__page.is-pushed {
+    transform: translateX(-@mobile-nav-width-fixed);
+  }
+
+  &.site--left .site__page.is-pushed {
+    transform: translateX(@mobile-nav-width-fixed);
+  }
+
+  &.site--stacked .site__page.is-pushed {
+    transform: translateX(0);
+  }
+
+  .respond(large, {
+    .site.is-mobile-nav-open {
+      overflow-y: inherit;
+    }
+
+    .site__page {
+      padding-right: @mobile-nav-width-fixed;
+      transform: translateX(0);
+    }
+
+    .site__page.is-pushed {
+      transform: translateX(0);
+    }
+
+    &.site--left .site__page {
+      padding-left: @mobile-nav-width-fixed;
+      padding-right: 0;
+      transform: translateX(0);
+    }
+
+    .site__page__mask.is-visible {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .site__mobile {
+      transform: translateX(0);
+      border-left: 1px solid @color-gray--light;
+    }
+
+    &.site--left .site__mobile {
+      border-right: 1px solid @color-gray--light;
+      border-left: none;
+    }
+  });
 }
 
 // Copyright AXA Versicherungen AG 2015

--- a/less/style/variables.less
+++ b/less/style/variables.less
@@ -154,8 +154,8 @@
 @z-index-button__badge: 9800;
 @z-index-popover: 9900;
 @z-index-notifications: 9950;
-@z-index-site-mobile-nav: 9960;
-@z-index-site-page-masked: 9961;
+@z-index-site-mobile-nav: 9961;
+@z-index-site-page-masked: 9960;
 @z-index-example-header: 9970;
 @z-index-backdrop: 9980;
 @z-index-burger-icon: 9981;


### PR DESCRIPTION
In an attempt to make our side nav more flexible, so we could use this style guide for the Web Guidelines website (yup, you got me right), I'm adding **three modifiers** to the `site` block.

## `site--left` modifier

This one flips our side nav to the other side. My recommendation is to adjust the header so the burger is on the left side, too.

![site--left](https://cloud.githubusercontent.com/assets/198988/18390956/7bb54132-76ac-11e6-814f-0f234f5db295.gif)

## `site--stacked` modifier

The side nav normally pushes the content away. The `stacked` modifier allows you to rather stack over the content.

![site--stacked](https://cloud.githubusercontent.com/assets/198988/18390973/a3b8791a-76ac-11e6-857e-e77c1dda9bf1.gif)

## `site--desktop` modifier

This one is the one with the biggest impact. It allows you to use the side nav on desktop, too! In order to not break compatibility, the side nav still resides in the `site__mobile` element. I recommend to keep this until we're going to make a bigger release and we're free to rename that one to `site__menu` or something similar.

![site--left--stacked--desktop](https://cloud.githubusercontent.com/assets/198988/18391091/113cb03c-76ad-11e6-98bb-3750967bdb37.gif)

* [x] Get feedback on the three modifiers
* [ ] Describe them in the docs