### PR TITLE
Let the header search set its display & looks

### DIFF
--- a/less/style/blocks/header-search.less
+++ b/less/style/blocks/header-search.less
@@ -1,8 +1,12 @@
 @import '../variables';
 @import '../mixins/font';
+@import '../mixins/make-link';
 @import './control';
 
 .header-search {
+  .make-link;
+
+  display: flex;
 }
 
 .header-search__input {

--- a/less/style/blocks/header.less
+++ b/less/style/blocks/header.less
@@ -74,10 +74,7 @@
 }
 
 .header__meta__item--search {
-  .make-link;
-
   order: 3;
-  display: flex;
 }
 
 .header__meta__item--language {


### PR DESCRIPTION
Only makes sense that the `header-search` block can decide by itself how it wants to look, right? This allows use the block in slightly different locations inside the header 🎉 