### PR TITLE
Remove silly "iOS app icon" comment from all our snippets

### DIFF
--- a/docs/layouts/examples/master.jade
+++ b/docs/layouts/examples/master.jade
@@ -13,7 +13,6 @@ html
     meta(name="keywords", content=config.keywords)
     meta(name="author", content=config.author)
 
-    // iOS app icon
     mixin appicon_ios(size)
       - var s = size + "x" + size
       link(rel="apple-touch-icon-precomposed", href="images/app-icon/ios/"+s+".png", sizes=s)

--- a/docs/page/components/includes/mixins.jade
+++ b/docs/page/components/includes/mixins.jade
@@ -87,7 +87,6 @@ mixin displayMobileMenu(page)
         each child in page.children
           +displayMobileMenu(child)
 
-// iOS app icon
 mixin appicon_ios(size)
   - var s = size + "x" + size
   link(rel="apple-touch-icon-precomposed", sizes=s, href=relative("/images/app-icon/ios/"+s+".png"))


### PR DESCRIPTION
Well, if you've seen it, you've probably been pretty confused. But because we had this comment in our mixins file that we included almost everywhere...

```jade
// iOS app icon
     mixin appicon_ios(size)
```

... it rendered as an HTML comment, which was included in almost all our snippets 😓.

Could have changed to `//- iOS app icon`, but thought this comment isn't really necessary.

<img width="1090" alt="screen shot 2016-09-12 at 23 45 40" src="https://cloud.githubusercontent.com/assets/198988/18454205/5f72886a-7943-11e6-98b6-4cebac401200.png">