### PR TITLE
Bugfix/mobile datepicker click icon v2

### DIFF
--- a/js/jquery/datepicker.js
+++ b/js/jquery/datepicker.js
@@ -212,6 +212,7 @@ class Datepicker {
 
   constructor(element, options) {
     this.onChange = this.onChange.bind(this)
+    this.onChangeMobileTrigger = this.onChangeMobileTrigger.bind(this)
     this.options = options
     this.moment = options.moment
     this.setLocale(options.locale)
@@ -226,8 +227,11 @@ class Datepicker {
       this.$input = $(options.input)
 
       this.$input.prop('type', 'date')
+      this.$input.on('change', this.onChange)
 
-      this.$input.focus()
+      this.$triggerMobile = this.$element.find('.datepicker__trigger__mobile')
+      this.$triggerMobile.val(this.$input.val())
+      this.$triggerMobile.on('change', this.onChangeMobileTrigger)
     } else {
       this.picker = new Picker(this.moment, options.displayWeek, options.icons, options.longDateFormat)
 
@@ -239,7 +243,7 @@ class Datepicker {
         this.onChange()
       }
 
-      this.picker.on('select', date => {
+      this.picker.on('select', (date) => {
         this.$input.val(date)
         this.$input.trigger('change')
       })
@@ -249,11 +253,19 @@ class Datepicker {
   }
 
   onChange() {
-    const dat = this.moment(this.$input.val(), this.format)
+    if (isMobile) {
+      this.$triggerMobile.val(this.$input.val())
+    } else {
+      const dat = this.moment(this.$input.val(), this.format)
 
-    if (dat.isValid()) {
-      this.picker.setSelectedDate(dat)
+      if (dat.isValid()) {
+        this.picker.setSelectedDate(dat)
+      }
     }
+  }
+
+  onChangeMobileTrigger() {
+    this.$input.val(this.$triggerMobile.val())
   }
 
   setLocale(locale) {
@@ -280,9 +292,7 @@ class Datepicker {
   }
 
   toggle() {
-    if (isMobile) {
-      this.$input.focus()
-    } else {
+    if (!isMobile) {
       this.picker.toggle()
     }
   }
@@ -290,8 +300,16 @@ class Datepicker {
 
 // Plugin definition
 registerPlugin('datepicker', Datepicker, (PluginWrapper) => {
+  if (isMobile) {
+    $('.datepicker__trigger').each(function () {
+      $(this).append($('<input type="date" class="datepicker__trigger__mobile">'))
+    })
+  }
+
   $(document).on('click.axa.datepicker.data-api', '[data-datepicker]', function (e) {
-    e.preventDefault()
+    if (!isMobile) {
+      e.preventDefault()
+    }
 
     const data = $(this).data()
     const $target = $(data.datepicker)

--- a/js/jquery/datepicker.js
+++ b/js/jquery/datepicker.js
@@ -205,7 +205,7 @@ class Picker extends Emitter {
 
 class Datepicker {
   static DEFAULTS = {
-    moment: window.moment,
+    moment: moment,
     locale: document.documentElement.lang || 'en',
     longDateFormat: 'L',
   }

--- a/less/style/blocks/datepicker.less
+++ b/less/style/blocks/datepicker.less
@@ -44,6 +44,7 @@
   cursor: pointer;
 
   display: block;
+  position: relative;
   float: right;
 
   width: 40px;
@@ -59,6 +60,16 @@
   fill: @color-light-blue;
   display: inline-block;
   vertical-align: middle;
+}
+
+.datepicker__trigger__mobile {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  opacity: 0;
+  background: transparent;
 }
 
 .picker {


### PR DESCRIPTION
fixes #555 

Unfortunately the native datepicker dialog does not show up on mobile if our icon is clicked.
This is because synthetic show/hide of mobile UI's like keyboard, HTML5 datepicker etc. triggered by JS is forbidden.

Hence I introduced a second invisible phantom datepicker, which is only in charge of hijacking clicks 😄 