### PR TITLE
Update npm deprecated deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "iframe-resizer": "^2.8.10",
     "jsdoc-babel": "^0.2.1",
     "jsdoc-to-markdown": "^2.0.0-alpha.15",
-    "jshint-stylish": "^1.0.1",
     "json-loader": "^0.5.4",
     "jstransformer-markdown-it": "^1.0.0",
     "jstransformer-marked": "^1.0.1",


### PR DESCRIPTION
fixes #604 

Todo:
- [x] Replace `jade` with `pug`
 - [x] Replace `metalsmith-jade` with `metalsmith-pug`
 - [x] Rewrite `.jade` file extension to `.pug`
- [x] replace deprecated `https://github.com/segmentio/metalsmith-templates` with suggested ones here: https://github.com/segmentio/metalsmith-templates
- [x] remove `jshint-stylish` devDependency (since we use ESLint)
- [x] remove `gulp-jshint`
- [ ] remove deprecated `gulp-foreach` - Either use gulp-tap or gulp-flatmap, depending on your needs

**Note** Gulp stuff could skipped, since we are refactoring the whole build w/o gulp

migration guide from jade to pug:
https://pugjs.org/api/migration-v2.html
https://pugjs.org/language/attributes.html#attribute-interpolation