### PR TITLE
Bugfix/remove fouc on dev completely

### DIFF
--- a/docs/layouts/inject.mixin.pug
+++ b/docs/layouts/inject.mixin.pug
@@ -5,5 +5,7 @@ mixin inject(type)
     if type === 'css'
       link(rel="stylesheet", href=relative("/dist/docs.min.css"))
   else
-    if type === 'css'
+    if type === 'js'
       script(src=relative('/dist/docs.js'))
+    if type === 'css'
+      link(rel="stylesheet", href=relative("/dist/docs.css"))

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "webpack-module-hot-accept": "^1.0.4",
     "webpack-svgstore-plugin": "^3.0.4",
     "webpack-uglify-parallel": "^0.1.2",
+    "write-file-webpack-plugin": "^3.3.0",
     "zeroclipboard": "^2.2.0"
   }
 }

--- a/webpack/browsersync-dev-server.js
+++ b/webpack/browsersync-dev-server.js
@@ -51,5 +51,6 @@ browserSync({
   // including full page reloads if HMR won't work
   files: [
     `${docsPath}/**/*.html`,
+    'dist/*.css',
   ],
 })

--- a/webpack/bundle.dev.config.babel.js
+++ b/webpack/bundle.dev.config.babel.js
@@ -2,7 +2,9 @@ import path from 'path'
 import webpack from 'webpack'
 import pseudoelements from 'postcss-pseudoelements'
 import autoprefixer from 'autoprefixer'
+import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import SvgStore from 'webpack-svgstore-plugin'
+import WriteFilePlugin from 'write-file-webpack-plugin';
 
 import createHappyPlugin, { getEnvId } from '../lib/createHappyPlugin'
 
@@ -37,7 +39,13 @@ export default {
       loader: `happypack/loader?id=${getEnvId('jsx')}`,
     }, {
       test: /\.scss$/,
-      loader: `happypack/loader?id=${getEnvId('sass')}`,
+      // loader: `happypack/loader?id=${getEnvId('sass')}`,
+      loader: ExtractTextPlugin.extract('style', [
+        'css?importLoaders=2&sourceMap',
+        'postcss-loader',
+        // 'custom-postcss',
+        'sass?outputStyle=expanded&sourceMap=true&sourceMapContents=true',
+      ]),
     }],
     noParse: [
       'jquery',
@@ -58,12 +66,18 @@ export default {
       'babel?cacheDirectory=true',
       'webpack-module-hot-accept',
     ]),
-    createHappyPlugin('sass', [
-      'style',
-      'css?importLoaders=2&sourceMap',
-      'postcss-loader',
-      'sass?outputStyle=expanded&sourceMap=true&sourceMapContents=true',
-    ]),
+    // createHappyPlugin('sass', [
+    //   'style',
+    //   'css?importLoaders=2&sourceMap',
+    //   'postcss-loader',
+    //   'sass?outputStyle=expanded&sourceMap=true&sourceMapContents=true',
+    // ]),
+    // Force write to disk for browser-sync css hot reloading
+    new WriteFilePlugin({ test: /\.css$/ }),
+    new ExtractTextPlugin('[name].css', {
+      publicPath: '/dist/',
+      allChunks: true,
+    }),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),


### PR DESCRIPTION
Since my first attempt to fix #615 the FOUC was not a complete success, though a huge improvement.

I investigated the HMR issue of CSS and webpack more carefully.

And as it turns out HMR'ed CSS would be fancy yes, but introduces the following issue:

- property changes cause transition even on first page load (the FOUC)
- You could not speed test the loading of you CSS in dev mode (cause it is inject as aBLOB ...)
- various stat tool incompatability ...
