### PR TITLE
lowercased icon id in our pug mixin to work with webpack svgstore plugin

### DIFF
--- a/docs/mixins.pug
+++ b/docs/mixins.pug
@@ -1,7 +1,7 @@
 mixin svg(id, classes, config)
   - config = config || {}
   - config.attrs = config.attrs || {}
-  - path = relative(config.path || '/dist/icons.svg') + '#' + id
+  - path = relative(config.path || '/dist/icons.svg') + '#' + id.toLowerCase()
   svg(class=classes)&attributes(config.attrs)
     use(xlink:href=path)
 


### PR DESCRIPTION
fixes #660 

@davidknezic 
I'm sure the exact same bug exist in the global styleguide too.