### PR TITLE
Improvement/make segmented control restack event available

### DIFF
--- a/js/jquery/segmented-control.js
+++ b/js/jquery/segmented-control.js
@@ -1,9 +1,12 @@
-/* global window */
+/* global window, document */
 
 import $ from 'jquery'
+import Bacon from 'baconjs'
 import registerPlugin from './register-plugin'
 import resizeStream from './resize-stream'
 import orientationchangeStream from './orientationchange-stream'
+
+const restackStream = Bacon.$.asEventStream.call($(document), 'axa.segment-control:restack')
 
 // Public class definition
 class SegmentedControl {
@@ -50,7 +53,7 @@ class SegmentedControl {
 
     this.stackControlsIfNeeded()
 
-    const reorientStream = resizeStream.merge(orientationchangeStream)
+    const reorientStream = resizeStream.merge(orientationchangeStream).merge(restackStream)
 
     this.disposeReorient = reorientStream.debounce(100)
       .onValue(this.stackControlsIfNeeded)

--- a/js/jquery/segmented-control.js
+++ b/js/jquery/segmented-control.js
@@ -67,7 +67,7 @@ class SegmentedControl {
     const availableWidth = $element.parent().innerWidth()
     const usedWidth = $element[0].scrollWidth
 
-    if (usedWidth >= availableWidth) {
+    if (usedWidth && availableWidth && usedWidth >= availableWidth) {
       $element.addClass('segmented-control--stacked')
     }
   }


### PR DESCRIPTION
Currently our `segmented-control` with the `--stacked` modifier does only respond to `resize`, `orientationchange` events. This is okay.

Though at axa.ch we face the issue, that all steps of a form are rendered but all inactive steps are set to `display:none` which leads to wrong `--stacked` detection and breaks if the user navigates through the steps.

Hence we need some sort of communication possibility from arbitrary components, libraries, etc to ask `segmented-control` please recheck if you need to stack your controls.

For this sake I have added an custom event listener on the `document` object which listens to `axa.segment-control:restack`.

Now any stuff just needs to do something like this:
```js
jQuery(document).trigger('axa.segment-control:restack')
```

**Note**
In case you think: oh nooo why should this event be connected with a DOM node 😱 
I agree unfortunately jQuery is made around DOM stuff and adding a non-DOM related event system is a bit overkill just for this...