### PR TITLE
disable uglifyjs warnings

### DIFF
--- a/webpack/bundle.config.babel.js
+++ b/webpack/bundle.config.babel.js
@@ -81,6 +81,9 @@ export default {
     }),
     new UglifyJsParallelPlugin({
       workers: os.cpus().length,
+      compress: {
+        warnings: false,
+      },
     }),
   ],
   resolveLoader: {


### PR DESCRIPTION
fixes #646 

Well I just disabled those warnings, we have eslint anyway and most of them are about vendor stuff, so...