### PR TITLE
Improvement/enable es7 annotations

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "plugins": [
     "transform-object-assign",
+    "transform-decorators-legacy",
     "transform-class-properties",
     "transform-es2015-destructuring",
     "transform-object-rest-spread"

--- a/docs/js/search.js
+++ b/docs/js/search.js
@@ -1,5 +1,6 @@
 /* global window */
 
+import { autobind } from 'core-decorators'
 import $ from 'jquery'
 import lunr from 'lunr'
 
@@ -36,9 +37,9 @@ class Search {
     // load the search data / index
     this.searchData = getSearchData(this.$input.data('search-index-data'))
 
-    this.searchData.done(this.initIndex.bind(this))
+    this.searchData.done(this.initIndex)
 
-    this.searchData.fail(this.fail.bind(this))
+    this.searchData.fail(this.fail)
 
     // register keyboard events
     this.$input.on('keyup', e => {
@@ -93,6 +94,7 @@ class Search {
     }
   }
 
+  @autobind
   fail() {
     this.error = true
 
@@ -100,6 +102,7 @@ class Search {
     this.updateDisplay()
   }
 
+  @autobind
   initIndex(data) {
     this.searchData = data
     this.lunrIdx = lunr.Index.load(this.searchData.lunr)

--- a/docs/js/search.js
+++ b/docs/js/search.js
@@ -1,6 +1,6 @@
 /* global window */
 
-import { autobind } from 'core-decorators'
+import autobind from 'core-decorators/lib/autobind'
 import $ from 'jquery'
 import lunr from 'lunr'
 

--- a/js/jquery/autogrow.js
+++ b/js/jquery/autogrow.js
@@ -1,6 +1,6 @@
 /* global window, document */
 
-import { autobind } from 'core-decorators'
+import autobind from 'core-decorators/lib/autobind'
 import $ from 'jquery'
 import registerPlugin from './register-plugin'
 

--- a/js/jquery/autogrow.js
+++ b/js/jquery/autogrow.js
@@ -1,5 +1,6 @@
 /* global window, document */
 
+import { autobind } from 'core-decorators'
 import $ from 'jquery'
 import registerPlugin from './register-plugin'
 
@@ -9,8 +10,6 @@ class Autogrow {
     this.element = element
     this.$element = $(element)
     this.options = $.extend({}, options)
-
-    this.update = this.update.bind(this)
 
     this.init()
   }
@@ -38,6 +37,8 @@ class Autogrow {
 
     $(window).resize(this.update)
   }
+
+  @autobind
   update(event) {
     if (this.element) {
       let val = this.element.value.replace(/</g, '&lt')

--- a/js/jquery/checkbox.js
+++ b/js/jquery/checkbox.js
@@ -1,5 +1,6 @@
 /* global window */
 
+import { autobind } from 'core-decorators'
 import $ from 'jquery'
 import registerPlugin from './register-plugin'
 
@@ -8,9 +9,6 @@ class Checkbox {
   static DEFAULTS
 
   constructor(element, options) {
-    this.handleKeyUp = this.handleKeyUp.bind(this)
-    this.setCheckboxState = this.setCheckboxState.bind(this)
-    this.handleCustomColorBG = this.handleCustomColorBG.bind(this)
     this.$element = $(element)
 
     // TODO: Do not depend on css classes
@@ -44,6 +42,7 @@ class Checkbox {
     }
   }
 
+  @autobind
   handleCustomColorBG() {
     if (this.$checkbox.is(':checked')) {
       this.$element.css({
@@ -59,6 +58,7 @@ class Checkbox {
   }
 
   // Handle spacebar to toggle the checkbox
+  @autobind
   handleKeyUp(e) {
     if (e.which === 32) {
       // prevent scrolling
@@ -72,6 +72,7 @@ class Checkbox {
   }
 
   // Updates the UI according to the checkbox state
+  @autobind
   setCheckboxState() {
     if (this.$checkbox.is(':checked')) {
       this.$element.addClass('is-active')

--- a/js/jquery/checkbox.js
+++ b/js/jquery/checkbox.js
@@ -1,6 +1,6 @@
 /* global window */
 
-import { autobind } from 'core-decorators'
+import autobind from 'core-decorators/lib/autobind'
 import $ from 'jquery'
 import registerPlugin from './register-plugin'
 

--- a/js/jquery/datepicker.js
+++ b/js/jquery/datepicker.js
@@ -1,6 +1,6 @@
 /* global window, document */
 
-import { autobind } from 'core-decorators'
+import autobind from 'core-decorators/lib/autobind'
 import $ from 'jquery'
 import moment from 'moment'
 import registerPlugin from './register-plugin'

--- a/js/jquery/datepicker.js
+++ b/js/jquery/datepicker.js
@@ -1,5 +1,6 @@
 /* global window, document */
 
+import { autobind } from 'core-decorators'
 import $ from 'jquery'
 import moment from 'moment'
 import registerPlugin from './register-plugin'
@@ -33,11 +34,11 @@ class Picker extends Emitter {
 
     this.$prev = append('<div class="picker__prev"></div>', this.$header)
     this.$prev.append(this.createIcon('prev'))
-    this.$prev.on('click', this.onPrevClick.bind(this))
+    this.$prev.on('click', this.onPrevClick)
 
     this.$next = append('<div class="picker__next"></div>', this.$header)
     this.$next.append(this.createIcon('next'))
-    this.$next.on('click', this.onNextClick.bind(this))
+    this.$next.on('click', this.onNextClick)
 
     this.$headline = append('<div class="picker__headline" ></div>', this.$header)
     this.$headline__month = append('<span class="picker__headline__month" ></span>', this.$headline)
@@ -188,6 +189,7 @@ class Picker extends Emitter {
     this.updateDisplay()
   }
 
+  @autobind
   onPrevClick(e) {
     e.preventDefault()
 
@@ -195,6 +197,7 @@ class Picker extends Emitter {
     this.updateDisplay()
   }
 
+  @autobind
   onNextClick(e) {
     e.preventDefault()
 
@@ -211,8 +214,6 @@ class Datepicker {
   }
 
   constructor(element, options) {
-    this.onChange = this.onChange.bind(this)
-    this.onChangeMobileTrigger = this.onChangeMobileTrigger.bind(this)
     this.options = options
     this.moment = options.moment
     this.setLocale(options.locale)
@@ -252,6 +253,7 @@ class Datepicker {
     }
   }
 
+  @autobind
   onChange() {
     if (isMobile) {
       this.$triggerMobile.val(this.$input.val())
@@ -264,6 +266,7 @@ class Datepicker {
     }
   }
 
+  @autobind
   onChangeMobileTrigger() {
     this.$input.val(this.$triggerMobile.val())
     this.$input.trigger('change')

--- a/js/jquery/dialog.js
+++ b/js/jquery/dialog.js
@@ -1,6 +1,6 @@
 /* global document */
 
-import { autobind } from 'core-decorators'
+import autobind from 'core-decorators/lib/autobind'
 import $ from 'jquery'
 import registerPlugin from './register-plugin'
 import icon from './icon'

--- a/js/jquery/dialog.js
+++ b/js/jquery/dialog.js
@@ -1,5 +1,6 @@
 /* global document */
 
+import { autobind } from 'core-decorators'
 import $ from 'jquery'
 import registerPlugin from './register-plugin'
 import icon from './icon'
@@ -109,10 +110,11 @@ class Dialog {
       closeEnabled: false,
       html: this.dialog,
       mode: 'fullscreen',
-      onBeforeClose: this.close.bind(this),
+      onBeforeClose: this.close,
     })
   }
 
+  @autobind
   close() {
     if (!this.isOpen) return
     this.isOpen = false

--- a/js/jquery/emitter.js
+++ b/js/jquery/emitter.js
@@ -1,4 +1,4 @@
-import { autobind } from 'core-decorators'
+import autobind from 'core-decorators/lib/autobind'
 
 class Emitter {
   constructor() {

--- a/js/jquery/emitter.js
+++ b/js/jquery/emitter.js
@@ -1,10 +1,11 @@
+import { autobind } from 'core-decorators'
+
 class Emitter {
   constructor() {
-    this.on = this.on.bind(this)
-    this.emit = this.emit.bind(this)
     this.events = {}
   }
 
+  @autobind
   on(eventName, cb) {
     // lazy pollute events map
     if (!(eventName in this.events)) {
@@ -13,6 +14,7 @@ class Emitter {
     this.events[eventName].push(cb)
   }
 
+  @autobind
   emit(eventName, ...args) {
     if (eventName in this.events) {
       this.events[eventName].map((fx) =>

--- a/js/jquery/modal2.js
+++ b/js/jquery/modal2.js
@@ -1,5 +1,6 @@
 /* global window, document */
 
+import { autobind } from 'core-decorators'
 import $ from 'jquery'
 import Bacon from 'baconjs'
 import registerPlugin from './register-plugin'
@@ -120,9 +121,6 @@ class Modal2 {
     this.options = options
     this.$html = $(document.documentElement)
     this.$body = $(document.body)
-
-    this.close = this.close.bind(this)
-    this.restrictFocus = this.restrictFocus.bind(this)
 
     this.init()
     this.isOpen = false
@@ -262,6 +260,7 @@ class Modal2 {
     })
   }
 
+  @autobind
   restrictFocus(event) {
     if (!$.contains(this.$modal[0], event.target)) {
       event.stopPropagation()
@@ -269,6 +268,7 @@ class Modal2 {
     }
   }
 
+  @autobind
   close() {
     if (!this.isOpen) return
     this.isOpen = false

--- a/js/jquery/modal2.js
+++ b/js/jquery/modal2.js
@@ -1,6 +1,6 @@
 /* global window, document */
 
-import { autobind } from 'core-decorators'
+import autobind from 'core-decorators/lib/autobind'
 import $ from 'jquery'
 import Bacon from 'baconjs'
 import registerPlugin from './register-plugin'

--- a/js/jquery/modal2.js
+++ b/js/jquery/modal2.js
@@ -208,7 +208,7 @@ class Modal2 {
       this.$body.addClass(this.options.classes.body)
     }
 
-    const preventDefault = this.options.onBeforeOpen(this, insert.bind(this))
+    const preventDefault = this.options.onBeforeOpen(this, this.insert)
 
     if (preventDefault === false) {
       return
@@ -217,27 +217,28 @@ class Modal2 {
     const href = this.element.href || this.options.href
 
     if (href) {
-      this.load(href, insert.bind(this))
+      this.load(href, this.insert)
     } else {
-      insert.call(this, this.options.html || $(this.options['']).clone())
+      this.insert(this.options.html || $(this.options['']).clone())
+    }
+  }
+
+  @autobind
+  insert(html) {
+    if (html) {
+      this.$content.append(html)
     }
 
-    function insert(html) {
-      if (html) {
-        this.$content.append(html)
-      }
+    this.$modal.addClass(this.options.classes.open)
+    this.$html.append(this.$modal)
 
-      this.$modal.addClass(this.options.classes.open)
-      this.$html.append(this.$modal)
-
-      if (this.options.autofocus) {
-        this.$content.focus()
-      }
-
-      this.bind()
-
-      this.options.onAfterOpen(this)
+    if (this.options.autofocus) {
+      this.$content.focus()
     }
+
+    this.bind()
+
+    this.options.onAfterOpen(this)
   }
 
   load(url, callback) {

--- a/js/jquery/popover.js
+++ b/js/jquery/popover.js
@@ -1,6 +1,6 @@
 /* global window, document */
 
-import { autobind } from 'core-decorators'
+import autobind from 'core-decorators/lib/autobind'
 import $ from 'jquery'
 import registerPlugin from './register-plugin'
 

--- a/js/jquery/popover.js
+++ b/js/jquery/popover.js
@@ -1,12 +1,12 @@
 /* global window, document */
 
+import { autobind } from 'core-decorators'
 import $ from 'jquery'
 import registerPlugin from './register-plugin'
 
 // Public class definition
 class Popover {
   constructor(element, options) {
-    this.position = this.position.bind(this)
     this.element = element
     this.$element = $(element)
     this.options = {
@@ -33,6 +33,7 @@ class Popover {
     event.data.$target.toggleClass('is-active')
   }
 
+  @autobind
   position() {
     const $box = this.$target.find('.popover__box')
     const $tail = this.$target.find('.popover__tail')

--- a/js/jquery/segmented-control.js
+++ b/js/jquery/segmented-control.js
@@ -1,6 +1,6 @@
 /* global window, document */
 
-import { autobind } from 'core-decorators'
+import autobind from 'core-decorators/lib/autobind'
 import $ from 'jquery'
 import Bacon from 'baconjs'
 import registerPlugin from './register-plugin'

--- a/js/jquery/segmented-control.js
+++ b/js/jquery/segmented-control.js
@@ -1,5 +1,6 @@
 /* global window, document */
 
+import { autobind } from 'core-decorators'
 import $ from 'jquery'
 import Bacon from 'baconjs'
 import registerPlugin from './register-plugin'
@@ -13,11 +14,6 @@ class SegmentedControl {
   static DEFAULTS
 
   constructor(element, options) {
-    this.handleKeyUp = this.handleKeyUp.bind(this)
-    this.handleKeyDown = this.handleKeyDown.bind(this)
-    this.setRadioState = this.setRadioState.bind(this)
-    this.stackControlsIfNeeded = this.stackControlsIfNeeded.bind(this)
-
     this.$element = $(element)
     const disabled = this.$element.is('[disabled=disabled]')
 
@@ -59,6 +55,7 @@ class SegmentedControl {
       .onValue(this.stackControlsIfNeeded)
   }
 
+  @autobind
   stackControlsIfNeeded() {
     const $element = this.$element
 
@@ -73,6 +70,7 @@ class SegmentedControl {
   }
 
   // Spacewar will activate first item if none is active
+  @autobind
   handleKeyUp(e) {
     if (e.which === 32) {
       e.preventDefault()
@@ -86,6 +84,7 @@ class SegmentedControl {
   }
 
   // Arrows will activate the next/previous radio
+  @autobind
   handleKeyDown(e) {
     let $checked
 
@@ -143,6 +142,7 @@ class SegmentedControl {
     }
   }
 
+  @autobind
   setRadioState() {
     this.$radios.each((index, element) => {
       const $radio = $(element)

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.5",
     "babel-plugin-transform-class-properties": "^6.10.2",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es2015-destructuring": "^6.9.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "baconjs": "^0.7.73",
     "classnames": "^2.2.5",
+    "core-decorators": "^0.14.0",
     "jquery": "^2.1.3",
     "moment": "^2.9.0",
     "react": "^15.3.0",


### PR DESCRIPTION
fixes #698 

I'm aware that ES7 decorators are [still not official](https://babeljs.io/docs/plugins/transform-decorators/). But I really like the feature.
Hence I decided to utilize [legacy decorator transform plugin](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy) for Babel 6.

Regarding specific `@decorator` implementations I quickly picked https://www.npmjs.com/package/core-decorators