### PR TITLE
important useless, cause it's order hence specifity is messed up by c…

### DIFF
--- a/lib/postcss-fix-ie-target-order.js
+++ b/lib/postcss-fix-ie-target-order.js
@@ -1,0 +1,31 @@
+import postcss from 'postcss'
+
+const reIeTarget = /\(-ms-high-contrast:\s?none\),\s?\(-ms-high-contrast:\s?active\)$/
+const fixIeTargetOrder = postcss.plugin('fixIeTargetOrder', () => (css) => {
+  let firstAtRule
+
+  css.walkAtRules('media', (atRule) => {
+    const { parent } = atRule
+
+    if (parent.type !== 'root') {
+      return
+    }
+
+    if (!firstAtRule) {
+      firstAtRule = atRule
+    }
+
+    const queryList = atRule.params
+
+    if (reIeTarget.test(queryList)) {
+      parent.insertBefore(firstAtRule, atRule.clone())
+
+      atRule.remove()
+    }
+  })
+
+  return css
+})
+
+// @todo: this temporarely fixes css-mqpacker incomplete sorting feature
+export default fixIeTargetOrder

--- a/scss/style/mixins/make-column-span.scss
+++ b/scss/style/mixins/make-column-span.scss
@@ -8,6 +8,6 @@
   flex: 0 0 $width;
 
   @include target(ie) {
-    max-width: $width !important;
+    max-width: $width;
   }
 }

--- a/webpack/custom-postcss.js
+++ b/webpack/custom-postcss.js
@@ -1,13 +1,16 @@
+require('babel-register')
 var postcss = require('postcss')
 var autoprefixer = require('autoprefixer')
 var cssmqpacker = require('css-mqpacker')
 var csswring = require('csswring')
 var pseudoelements = require('postcss-pseudoelements')
+var fixIeTargetOrder = require('../lib/postcss-fix-ie-target-order').default
 
 var processor = postcss([
   pseudoelements,
   autoprefixer,
   cssmqpacker({ sort: true }),
+  fixIeTargetOrder(),
   csswring,
 ])
 


### PR DESCRIPTION
…ss-mqpacker

fixes #729 

The specifity issue is caused by `css-mqpacker`'s sort method.